### PR TITLE
update CTRE, Rev, Kauai vendordeps

### DIFF
--- a/src/main/java/com/team766/hal/wpilib/NavXGyro.java
+++ b/src/main/java/com/team766/hal/wpilib/NavXGyro.java
@@ -8,48 +8,49 @@ import com.team766.hal.GyroReader;
 import edu.wpi.first.wpilibj.I2C;
 
 public class NavXGyro implements GyroReader {
-	private AHRS m_gyro;
+    private AHRS m_gyro;
 
-	public NavXGyro(final I2C.Port port) {
-		m_gyro = new AHRS(port);
-		// NOTE: It takes a bit of time until the gyro reader thread updates
-		// the connected status, so we can't check it immediately.
-		// TODO: Replace this with a status indicator
-		/*if (!m_gyro.isConnected()) {
-			Logger.get(Category.HAL).logData(Severity.ERROR, "NavX Gyro is not connected!");
-		} else {
-			Logger.get(Category.HAL).logData(Severity.INFO, "NavX Gyro is connected");
-		}*/
-	}
+    public NavXGyro(final I2C.Port port) {
+        m_gyro = new AHRS(port);
+        // NOTE: It takes a bit of time until the gyro reader thread updates
+        // the connected status, so we can't check it immediately.
+        // TODO: Replace this with a status indicator
+        /*if (!m_gyro.isConnected()) {
+        	Logger.get(Category.HAL).logData(Severity.ERROR, "NavX Gyro is not connected!");
+        } else {
+        	Logger.get(Category.HAL).logData(Severity.INFO, "NavX Gyro is connected");
+        }*/
+    }
 
-	@Override
-	public void calibrate() {
-		m_gyro.calibrate();
-	}
+    @Override
+    public void calibrate() {
+        // m_gyro.calibrate(); calibrate() seems to have been removed.
+        // it may have been a no-op anyway?
+        // https://github.com/kauailabs/navxmxp/blob/master/roborio/java/navx_frc/src/com/kauailabs/navx/frc/AHRS.java
+    }
 
-	@Override
-	public void reset() {
-		m_gyro.reset();
-	}
+    @Override
+    public void reset() {
+        m_gyro.reset();
+    }
 
-	@Override
-	public double getAngle() {
-		return m_gyro.getAngle();
-	}
+    @Override
+    public double getAngle() {
+        return m_gyro.getAngle();
+    }
 
-	@Override
-	public double getRate() {
-		return m_gyro.getRate();
-	}
+    @Override
+    public double getRate() {
+        return m_gyro.getRate();
+    }
 
-	@Override
-	public double getPitch() {
-		return m_gyro.getPitch();
-	}
+    @Override
+    public double getPitch() {
+        return m_gyro.getPitch();
+    }
 
-	@Override
-	public double getRoll() {
-		return m_gyro.getRoll();
-	}
-
+    @Override
+    public double getRoll() {
+        return m_gyro.getRoll();
+    }
 }

--- a/src/main/java/com/team766/robot/gatorade/mechanisms/Elevator.java
+++ b/src/main/java/com/team766/robot/gatorade/mechanisms/Elevator.java
@@ -3,9 +3,9 @@ package com.team766.robot.gatorade.mechanisms;
 import static com.team766.robot.gatorade.constants.ConfigConstants.*;
 
 import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkMax.ControlType;
-import com.revrobotics.SparkMaxPIDController;
+import com.revrobotics.SparkPIDController;
 import com.team766.config.ConfigFileReader;
 import com.team766.framework.Mechanism;
 import com.team766.hal.MotorController;
@@ -58,7 +58,7 @@ public class Elevator extends Mechanism {
 
     private final CANSparkMax leftMotor;
     private final CANSparkMax rightMotor;
-    private final SparkMaxPIDController pidController;
+    private final SparkPIDController pidController;
     private final ValueProvider<Double> pGain;
     private final ValueProvider<Double> iGain;
     private final ValueProvider<Double> dGain;

--- a/src/main/java/com/team766/robot/gatorade/mechanisms/Shoulder.java
+++ b/src/main/java/com/team766/robot/gatorade/mechanisms/Shoulder.java
@@ -3,9 +3,9 @@ package com.team766.robot.gatorade.mechanisms;
 import static com.team766.robot.gatorade.constants.ConfigConstants.*;
 
 import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkMax.ControlType;
-import com.revrobotics.SparkMaxPIDController;
+import com.revrobotics.SparkPIDController;
 import com.team766.config.ConfigFileReader;
 import com.team766.framework.Mechanism;
 import com.team766.hal.MotorController;
@@ -60,7 +60,7 @@ public class Shoulder extends Mechanism {
 
     private final CANSparkMax leftMotor;
     private final CANSparkMax rightMotor;
-    private final SparkMaxPIDController pidController;
+    private final SparkPIDController pidController;
     private final ValueProvider<Double> pGain;
     private final ValueProvider<Double> iGain;
     private final ValueProvider<Double> dGain;

--- a/src/main/java/com/team766/robot/gatorade/mechanisms/Wrist.java
+++ b/src/main/java/com/team766/robot/gatorade/mechanisms/Wrist.java
@@ -2,9 +2,9 @@ package com.team766.robot.gatorade.mechanisms;
 
 import static com.team766.robot.gatorade.constants.ConfigConstants.*;
 
+import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkMax.ControlType;
-import com.revrobotics.SparkMaxPIDController;
+import com.revrobotics.SparkPIDController;
 import com.team766.config.ConfigFileReader;
 import com.team766.framework.Mechanism;
 import com.team766.hal.MotorController;
@@ -59,7 +59,7 @@ public class Wrist extends Mechanism {
     private static final double NEAR_THRESHOLD = 5.0;
 
     private final CANSparkMax motor;
-    private final SparkMaxPIDController pidController;
+    private final SparkPIDController pidController;
     private final ValueProvider<Double> pGain;
     private final ValueProvider<Double> iGain;
     private final ValueProvider<Double> dGain;

--- a/vendordeps/NavX.json
+++ b/vendordeps/NavX.json
@@ -1,26 +1,26 @@
 {
-    "fileName": "navx_frc.json",
-    "name": "KauaiLabs_navX_FRC",
-    "version": "4.0.447",
-    "frcYear": "2024",
+    "fileName": "NavX.json",
+    "name": "NavX",
+    "version": "2024.1.0",
     "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
+    "frcYear": "2024",
     "mavenUrls": [
-        "https://repo1.maven.org/maven2/"
+        "https://dev.studica.com/maven/release/2024/"
     ],
-    "jsonUrl": "https://www.kauailabs.com/dist/frc/2022/navx_frc.json",
+    "jsonUrl": "https://dev.studica.com/releases/2024/NavX.json",
     "javaDependencies": [
         {
             "groupId": "com.kauailabs.navx.frc",
-            "artifactId": "navx-java",
-            "version": "4.0.447"
+            "artifactId": "navx-frc-java",
+            "version": "2024.1.0"
         }
     ],
     "jniDependencies": [],
     "cppDependencies": [
         {
             "groupId": "com.kauailabs.navx.frc",
-            "artifactId": "navx-cpp",
-            "version": "4.0.447",
+            "artifactId": "navx-frc-cpp",
+            "version": "2024.1.0",
             "headerClassifier": "headers",
             "sourcesClassifier": "sources",
             "sharedLibrary": false,
@@ -29,6 +29,10 @@
             "binaryPlatforms": [
                 "linuxathena",
                 "linuxraspbian",
+                "linuxarm32",
+                "linuxarm64",
+                "linuxx86-64",
+                "osxuniversal",
                 "windowsx86-64"
             ]
         }

--- a/vendordeps/Phoenix5.json
+++ b/vendordeps/Phoenix5.json
@@ -1,0 +1,151 @@
+{
+    "fileName": "Phoenix5.json",
+    "name": "CTRE-Phoenix (v5)",
+    "version": "5.33.0",
+    "frcYear": 2024,
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "mavenUrls": [
+        "https://maven.ctr-electronics.com/release/"
+    ],
+    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix/Phoenix5-frc2024-latest.json",
+    "requires": [
+        {
+            "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
+            "errorMessage": "Phoenix 5 requires low-level libraries from Phoenix 6.  Please add the Phoenix 6 vendordep before adding Phoenix 5.",
+            "offlineFileName": "Phoenix6.json",
+            "onlineUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix6/latest/Phoenix6-frc2024-latest.json"
+        }
+    ],
+    "javaDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-java",
+            "version": "5.33.0"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-java",
+            "version": "5.33.0"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.33.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.33.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-cpp",
+            "version": "5.33.0",
+            "libName": "CTRE_Phoenix_WPI",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-cpp",
+            "version": "5.33.0",
+            "libName": "CTRE_Phoenix",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.33.0",
+            "libName": "CTRE_PhoenixCCI",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "wpiapi-cpp-sim",
+            "version": "5.33.0",
+            "libName": "CTRE_Phoenix_WPISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "api-cpp-sim",
+            "version": "5.33.0",
+            "libName": "CTRE_PhoenixSim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.33.0",
+            "libName": "CTRE_PhoenixCCISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        }
+    ]
+}

--- a/vendordeps/Phoenix6.json
+++ b/vendordeps/Phoenix6.json
@@ -1,56 +1,32 @@
 {
-    "fileName": "Phoenix.json",
-    "name": "CTRE-Phoenix (v5)",
-    "version": "5.30.4+23.0.8",
+    "fileName": "Phoenix6.json",
+    "name": "CTRE-Phoenix (v6)",
+    "version": "24.1.0",
     "frcYear": 2024,
-    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
         "https://maven.ctr-electronics.com/release/"
     ],
-    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix/Phoenix5-frc2023-latest.json",
+    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix6/latest/Phoenix6-frc2024-latest.json",
+    "conflictsWith": [
+        {
+            "uuid": "3fcf3402-e646-4fa6-971e-18afe8173b1a",
+            "errorMessage": "The combined Phoenix-6-And-5 vendordep is no longer supported. Please remove the vendordep and instead add both the latest Phoenix 6 vendordep and Phoenix 5 vendordep.",
+            "offlineFileName": "Phoenix6And5.json"
+        }
+    ],
     "javaDependencies": [
         {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "api-java",
-            "version": "5.30.4"
-        },
-        {
-            "groupId": "com.ctre.phoenix",
+            "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-java",
-            "version": "5.30.4"
+            "version": "24.1.0"
         }
     ],
     "jniDependencies": [
         {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "cci",
-            "version": "5.30.4",
-            "isJar": false,
-            "skipInvalidPlatforms": true,
-            "validPlatforms": [
-                "windowsx86-64",
-                "linuxx86-64",
-                "linuxathena"
-            ],
-            "simMode": "hwsim"
-        },
-        {
-            "groupId": "com.ctre.phoenix.sim",
-            "artifactId": "cci-sim",
-            "version": "5.30.4",
-            "isJar": false,
-            "skipInvalidPlatforms": true,
-            "validPlatforms": [
-                "windowsx86-64",
-                "linuxx86-64",
-                "osxuniversal"
-            ],
-            "simMode": "swsim"
-        },
-        {
-            "groupId": "com.ctre.phoenixpro",
+            "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -61,9 +37,9 @@
             "simMode": "hwsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -74,9 +50,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -87,9 +63,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -100,9 +76,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -113,9 +89,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -126,9 +102,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -139,9 +115,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -152,9 +128,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -165,9 +141,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -180,10 +156,10 @@
     ],
     "cppDependencies": [
         {
-            "groupId": "com.ctre.phoenix",
+            "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-cpp",
-            "version": "5.30.4",
-            "libName": "CTRE_Phoenix_WPI",
+            "version": "24.1.0",
+            "libName": "CTRE_Phoenix6_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
             "skipInvalidPlatforms": true,
@@ -195,39 +171,9 @@
             "simMode": "hwsim"
         },
         {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "api-cpp",
-            "version": "5.30.4",
-            "libName": "CTRE_Phoenix",
-            "headerClassifier": "headers",
-            "sharedLibrary": true,
-            "skipInvalidPlatforms": true,
-            "binaryPlatforms": [
-                "windowsx86-64",
-                "linuxx86-64",
-                "linuxathena"
-            ],
-            "simMode": "hwsim"
-        },
-        {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "cci",
-            "version": "5.30.4",
-            "libName": "CTRE_PhoenixCCI",
-            "headerClassifier": "headers",
-            "sharedLibrary": true,
-            "skipInvalidPlatforms": true,
-            "binaryPlatforms": [
-                "windowsx86-64",
-                "linuxx86-64",
-                "linuxathena"
-            ],
-            "simMode": "hwsim"
-        },
-        {
-            "groupId": "com.ctre.phoenixpro",
+            "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -240,10 +186,10 @@
             "simMode": "hwsim"
         },
         {
-            "groupId": "com.ctre.phoenix.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "5.30.4",
-            "libName": "CTRE_Phoenix_WPISim",
+            "version": "24.1.0",
+            "libName": "CTRE_Phoenix6_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
             "skipInvalidPlatforms": true,
@@ -255,39 +201,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenix.sim",
-            "artifactId": "api-cpp-sim",
-            "version": "5.30.4",
-            "libName": "CTRE_PhoenixSim",
-            "headerClassifier": "headers",
-            "sharedLibrary": true,
-            "skipInvalidPlatforms": true,
-            "binaryPlatforms": [
-                "windowsx86-64",
-                "linuxx86-64",
-                "osxuniversal"
-            ],
-            "simMode": "swsim"
-        },
-        {
-            "groupId": "com.ctre.phoenix.sim",
-            "artifactId": "cci-sim",
-            "version": "5.30.4",
-            "libName": "CTRE_PhoenixCCISim",
-            "headerClassifier": "headers",
-            "sharedLibrary": true,
-            "skipInvalidPlatforms": true,
-            "binaryPlatforms": [
-                "windowsx86-64",
-                "linuxx86-64",
-                "osxuniversal"
-            ],
-            "simMode": "swsim"
-        },
-        {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -300,9 +216,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -315,9 +231,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -330,9 +246,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -345,9 +261,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -360,9 +276,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -375,9 +291,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -390,9 +306,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -405,9 +321,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.8",
+            "version": "24.1.0",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -1,25 +1,25 @@
 {
     "fileName": "REVLib.json",
     "name": "REVLib",
-    "version": "2023.1.3",
+    "version": "2024.2.0",
     "frcYear": "2024",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
     "mavenUrls": [
         "https://maven.revrobotics.com/"
     ],
-    "jsonUrl": "https://software-metadata.revrobotics.com/REVLib-2023.json",
+    "jsonUrl": "https://software-metadata.revrobotics.com/REVLib-2024.json",
     "javaDependencies": [
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-java",
-            "version": "2023.1.3"
+            "version": "2024.2.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2023.1.3",
+            "version": "2024.2.0",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -37,7 +37,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-cpp",
-            "version": "2023.1.3",
+            "version": "2024.2.0",
             "libName": "REVLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -55,7 +55,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2023.1.3",
+            "version": "2024.2.0",
             "libName": "REVLibDriver",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
## Description

- update the vendordeps for CTRE, REV, and Kauai (NavX gyro) libraries.
- add Phoenix 6 libraries.  will update some of the CTRE devices to Phoenix 6 APIs in a subsequent PR.
- update Gatorade code (in this repo) to backwards-incompatible changes in REV API.s
- update NavX Gyro code to removal of AHRS.calibrate() API.

## How Has This Been Tested?

- [x] On-robot bench testing: Tested Phoenix 5 code paths on Gatorade.  Will test REV shortly (changes appear to be renaming of some libraries).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Team766/2024/7)
<!-- Reviewable:end -->
