### PR TITLE
checking context ownership when resetting gyro

### DIFF
--- a/src/main/java/com/team766/robot/common/mechanisms/Drive.java
+++ b/src/main/java/com/team766/robot/common/mechanisms/Drive.java
@@ -174,6 +174,7 @@ public class Drive extends Mechanism {
     }
 
     public void resetGyro() {
+        checkContextOwnership();
         gyro.reset();
     }
 


### PR DESCRIPTION
check context ownership in Drive.resetGyro(), as per previous PR feedback.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Team766/2024/9)
<!-- Reviewable:end -->
