### PR TITLE
add support to read and write configuration to USB by default

### DIFF
--- a/src/main/java/com/team766/config/ConfigFileReader.java
+++ b/src/main/java/com/team766/config/ConfigFileReader.java
@@ -1,5 +1,10 @@
 package com.team766.config;
 
+import com.team766.library.SettableValueProvider;
+import com.team766.logging.Category;
+import com.team766.logging.Logger;
+import com.team766.logging.LoggerExceptionUtils;
+import com.team766.logging.Severity;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringReader;
@@ -8,11 +13,6 @@ import java.nio.file.Paths;
 import java.util.regex.Pattern;
 import org.json.JSONObject;
 import org.json.JSONTokener;
-import com.team766.library.SettableValueProvider;
-import com.team766.logging.Category;
-import com.team766.logging.Logger;
-import com.team766.logging.LoggerExceptionUtils;
-import com.team766.logging.Severity;
 
 /**
  * Class for loading in config from the Config file.
@@ -23,159 +23,176 @@ import com.team766.logging.Severity;
  * @author Brett Levenson
  */
 public class ConfigFileReader {
-	// this.getClass().getClassLoader().getResource(fileName).getPath()
+    // this.getClass().getClassLoader().getResource(fileName).getPath()
 
-	public static ConfigFileReader instance;
+    public static ConfigFileReader instance;
 
-	private static final String KEY_DELIMITER = ".";
+    private static final String KEY_DELIMITER = ".";
 
-	// This is incremented each time the config file is reloaded to ensure that ConfigValues use the most recent setting.
-	private int m_generation = 0;
+    // This is incremented each time the config file is reloaded to ensure that ConfigValues use the
+    // most recent setting.
+    private int m_generation = 0;
 
-	private String m_fileName;
-	private JSONObject m_values = new JSONObject();
+    private String m_fileName;
+    private String m_backupFileName; // if set, will also save here
+    private JSONObject m_values = new JSONObject();
 
-	public static ConfigFileReader getInstance() {
-		return instance;
-	}
+    public static ConfigFileReader getInstance() {
+        return instance;
+    }
 
-	public ConfigFileReader(final String fileName) {
-		m_fileName = fileName;
+    public ConfigFileReader(final String fileName, final String backupFileName) {
+        m_fileName = fileName;
+        m_backupFileName = backupFileName;
 
-		try {
-			reloadFromFile();
-		} catch (Exception e) {
-			System.err.println("Failed to load config file!");
-			e.printStackTrace();
-			LoggerExceptionUtils.logException(new IOException("Failed to load config file!", e));
-		}
-	}
+        try {
+            reloadFromFile();
+        } catch (Exception e) {
+            System.err.println("Failed to load config file!");
+            e.printStackTrace();
+            LoggerExceptionUtils.logException(new IOException("Failed to load config file!", e));
+        }
+    }
 
-	public void reloadFromFile() throws IOException {
-		System.out.println("Loading config file: " + m_fileName);
-		String jsonString = Files.readString(Paths.get(m_fileName));
-		reloadFromJson(jsonString);
-	}
+    public ConfigFileReader(final String fileName) {
+        this(fileName, null /* backup file name */);
+    }
 
-	public void reloadFromJson(final String jsonString) {
-		JSONObject newValues;
-		try (StringReader reader = new StringReader(jsonString)) {
-			newValues = new JSONObject(new JSONTokener(reader));
-		}
-		for (AbstractConfigValue<?> param : AbstractConfigValue.accessedValues()) {
-			var rawValue = getRawValue(newValues, param.getKey());
-			if (rawValue == null) {
-				continue;
-			}
-			try {
-				param.parseJsonValue(rawValue);
-			} catch (Exception ex) {
-				throw new ConfigValueParseException(
-						"Could not parse config value for " + param.getKey(), ex);
-			}
-		}
-		m_values = newValues;
-		++m_generation;
-	}
+    public void reloadFromFile() throws IOException {
+        System.out.println("Loading config file: " + m_fileName);
+        String jsonString = Files.readString(Paths.get(m_fileName));
+        reloadFromJson(jsonString);
+    }
 
-	public int getGeneration() {
-		return m_generation;
-	}
+    public void reloadFromJson(final String jsonString) {
+        JSONObject newValues;
+        try (StringReader reader = new StringReader(jsonString)) {
+            newValues = new JSONObject(new JSONTokener(reader));
+        }
+        for (AbstractConfigValue<?> param : AbstractConfigValue.accessedValues()) {
+            var rawValue = getRawValue(newValues, param.getKey());
+            if (rawValue == null) {
+                continue;
+            }
+            try {
+                param.parseJsonValue(rawValue);
+            } catch (Exception ex) {
+                throw new ConfigValueParseException(
+                        "Could not parse config value for " + param.getKey(), ex);
+            }
+        }
+        m_values = newValues;
+        ++m_generation;
+    }
 
-	public boolean containsKey(final String key) {
-		return getRawValue(key) != null;
-	}
+    public int getGeneration() {
+        return m_generation;
+    }
 
-	public SettableValueProvider<Integer[]> getInts(final String key) {
-		return new IntegerConfigMultiValue(key);
-	}
+    public boolean containsKey(final String key) {
+        return getRawValue(key) != null;
+    }
 
-	public SettableValueProvider<Integer> getInt(final String key) {
-		return new IntegerConfigValue(key);
-	}
+    public SettableValueProvider<Integer[]> getInts(final String key) {
+        return new IntegerConfigMultiValue(key);
+    }
 
-	public SettableValueProvider<Double[]> getDoubles(final String key) {
-		return new DoubleConfigMultiValue(key);
-	}
+    public SettableValueProvider<Integer> getInt(final String key) {
+        return new IntegerConfigValue(key);
+    }
 
-	public SettableValueProvider<Double> getDouble(final String key) {
-		return new DoubleConfigValue(key);
-	}
+    public SettableValueProvider<Double[]> getDoubles(final String key) {
+        return new DoubleConfigMultiValue(key);
+    }
 
-	public SettableValueProvider<Boolean> getBoolean(final String key) {
-		return new BooleanConfigValue(key);
-	}
+    public SettableValueProvider<Double> getDouble(final String key) {
+        return new DoubleConfigValue(key);
+    }
 
-	public SettableValueProvider<String> getString(final String key) {
-		return new StringConfigValue(key);
-	}
+    public SettableValueProvider<Boolean> getBoolean(final String key) {
+        return new BooleanConfigValue(key);
+    }
 
-	public <E extends Enum<E>> SettableValueProvider<E> getEnum(final Class<E> enumClass,
-			final String key) {
-		return new EnumConfigValue<E>(enumClass, key);
-	}
+    public SettableValueProvider<String> getString(final String key) {
+        return new StringConfigValue(key);
+    }
 
-	public <E> void setValue(final String key, final E value) {
-		String[] keyParts = splitKey(key);
-		JSONObject parentObj = getParent(m_values, keyParts);
-		parentObj.putOpt(keyParts[keyParts.length - 1], value == null ? JSONObject.NULL : value);
-	}
+    public <E extends Enum<E>> SettableValueProvider<E> getEnum(
+            final Class<E> enumClass, final String key) {
+        return new EnumConfigValue<E>(enumClass, key);
+    }
 
-	Object getRawValue(final String key) {
-		return getRawValue(m_values, key);
-	}
+    public <E> void setValue(final String key, final E value) {
+        String[] keyParts = splitKey(key);
+        JSONObject parentObj = getParent(m_values, keyParts);
+        parentObj.putOpt(keyParts[keyParts.length - 1], value == null ? JSONObject.NULL : value);
+    }
 
-	private static Object getRawValue(final JSONObject obj, final String key) {
-		String[] keyParts = splitKey(key);
-		JSONObject parentObj = getParent(obj, keyParts);
-		var rawValue = parentObj.opt(keyParts[keyParts.length - 1]);
-		if (rawValue instanceof JSONObject) {
-			throw new IllegalArgumentException("The config file cannot store both a single config "
-					+ "setting and a group of config settings with the name " + key
-					+ " Please pick a different name");
-		}
-		if (rawValue == null) {
-			parentObj.put(keyParts[keyParts.length - 1], JSONObject.NULL);
-		}
-		if (rawValue == JSONObject.NULL) {
-			rawValue = null;
-		}
-		return rawValue;
-	}
+    Object getRawValue(final String key) {
+        return getRawValue(m_values, key);
+    }
 
-	private static String[] splitKey(final String key) {
-		return key.split(Pattern.quote(KEY_DELIMITER));
-	}
+    private static Object getRawValue(final JSONObject obj, final String key) {
+        String[] keyParts = splitKey(key);
+        JSONObject parentObj = getParent(obj, keyParts);
+        var rawValue = parentObj.opt(keyParts[keyParts.length - 1]);
+        if (rawValue instanceof JSONObject) {
+            throw new IllegalArgumentException(
+                    "The config file cannot store both a single config "
+                            + "setting and a group of config settings with the name "
+                            + key
+                            + " Please pick a different name");
+        }
+        if (rawValue == null) {
+            parentObj.put(keyParts[keyParts.length - 1], JSONObject.NULL);
+        }
+        if (rawValue == JSONObject.NULL) {
+            rawValue = null;
+        }
+        return rawValue;
+    }
 
-	private static JSONObject getParent(JSONObject obj, final String[] keyParts) {
-		for (int i = 0; i < keyParts.length - 1; ++i) {
-			JSONObject subObj;
-			try {
-				subObj = (JSONObject) obj.opt(keyParts[i]);
-			} catch (ClassCastException ex) {
-				throw new IllegalArgumentException(
-						"The config file cannot store both a single config "
-								+ "setting and a group of config settings with the name "
-								+ String.join(KEY_DELIMITER, keyParts)
-								+ " Please pick a different name for one of them.");
-			}
-			if (subObj == null) {
-				subObj = new JSONObject();
-				obj.put(keyParts[i], subObj);
-			}
-			obj = subObj;
-		}
-		return obj;
-	}
+    private static String[] splitKey(final String key) {
+        return key.split(Pattern.quote(KEY_DELIMITER));
+    }
 
-	public String getJsonString() {
-		return m_values.toString(2);
-	}
+    private static JSONObject getParent(JSONObject obj, final String[] keyParts) {
+        for (int i = 0; i < keyParts.length - 1; ++i) {
+            JSONObject subObj;
+            try {
+                subObj = (JSONObject) obj.opt(keyParts[i]);
+            } catch (ClassCastException ex) {
+                throw new IllegalArgumentException(
+                        "The config file cannot store both a single config "
+                                + "setting and a group of config settings with the name "
+                                + String.join(KEY_DELIMITER, keyParts)
+                                + " Please pick a different name for one of them.");
+            }
+            if (subObj == null) {
+                subObj = new JSONObject();
+                obj.put(keyParts[i], subObj);
+            }
+            obj = subObj;
+        }
+        return obj;
+    }
 
-	public void saveFile(final String jsonString) throws IOException {
-		try (FileWriter writer = new FileWriter(m_fileName)) {
-			writer.write(jsonString);
-		}
-		Logger.get(Category.CONFIGURATION).logRaw(Severity.INFO, "Config file written to " + m_fileName);
-	}
+    public String getJsonString() {
+        return m_values.toString(2);
+    }
+
+    private void saveFileToPath(final String jsonString, final String path) throws IOException {
+        try (FileWriter writer = new FileWriter(path)) {
+            writer.write(jsonString);
+        }
+        Logger.get(Category.CONFIGURATION).logRaw(Severity.INFO, "Config file written to " + path);
+    }
+
+    public void saveFile(final String jsonString) throws IOException {
+        saveFileToPath(jsonString, m_fileName);
+
+        if (m_backupFileName != null) {
+            saveFileToPath(jsonString, m_backupFileName);
+        }
+    }
 }

--- a/src/main/java/com/team766/hal/wpilib/RobotMain.java
+++ b/src/main/java/com/team766/hal/wpilib/RobotMain.java
@@ -68,14 +68,17 @@ public class RobotMain extends TimedRobot {
     @Override
     public void robotInit() {
         try {
+            boolean configFromUSB = true;
             String filename = null;
             filename = checkForAndReturnPathToConfigFile(USB_CONFIG_FILE);
 
             if (filename == null) {
                 filename = INTERNAL_CONFIG_FILE;
+                configFromUSB = false;
             }
 
-            ConfigFileReader.instance = new ConfigFileReader(filename);
+            ConfigFileReader.instance =
+                    new ConfigFileReader(filename, configFromUSB ? INTERNAL_CONFIG_FILE : null);
             RobotProvider.instance = new WPIRobotProvider();
             robot = new GenericRobotMain();
 


### PR DESCRIPTION
## Description

- `RobotMain` will now prefer reading and writing the robot config from `/U/config`, backing off to the internal (RoboRio SD card) path we currently use.
- if this USB location is used, writing configs will also be written to the internal path as well.
- removes support for reading configs from the `deploy` directory.

## How Has This Been Tested?

Will test on robot before submitting.  Sending for initial feedback.

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [x] On-robot bench testing: tested on Gatorade.  made edits to config, saw the changes on both USB and internal.
- [ ] On-robot field testing: [Add your description here]

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Team766/2024/10)
<!-- Reviewable:end -->
