### PR TITLE
temporarily disable CanivPoller

### DIFF
--- a/src/main/java/com/team766/hal/wpilib/RobotMain.java
+++ b/src/main/java/com/team766/hal/wpilib/RobotMain.java
@@ -42,6 +42,16 @@ public class RobotMain extends LoggedRobot {
 
         // periodically poll "caniv" in the background, if present
         CanivPoller canivPoller = null;
+
+        // UPDATE 1/21/2024: temporarily disable this poller
+        // Prior to 2024, Phoenix Tuner only installed the "caniv" binary on the RoboRio when
+        // a CANivore was configured.  Now, "caniv" is part of the 2024 RoboRio system image
+        // even if a CANivore is never configured or used.
+        // Thus, we will need to find a different way to condition when we poll.
+        // eg, instead of conditioning on whether or not the caniv binary is present,
+        // via the presence of a value in the config file, via an invocation of caniv to
+        // see if any CAN buses are present, etc.  Until we update this logic, we'll
+        // temporarily disable this altogether with a short-circuit AND.
         if (false && new File(CanivPoller.CANIV_BIN).exists()) {
             canivPoller = new CanivPoller(10 * 1000 /* millis */);
             new Thread(canivPoller, "caniv poller").start();


### PR DESCRIPTION
## Description

the 2024 RoboRio image includes the `caniv` binary in all cases, not just when you configure a CANivore.  temporarily disable this poller until we can change our conditioning logic to run it.


## How Has This Been Tested?

tested on several robots

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [x] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Team766/2024/16)
<!-- Reviewable:end -->
