### PR TITLE
update MaroonFramework to handle unspecified CAN bus values better

### DIFF
--- a/src/main/java/com/team766/hal/wpilib/WPIRobotProvider.java
+++ b/src/main/java/com/team766/hal/wpilib/WPIRobotProvider.java
@@ -110,6 +110,10 @@ public class WPIRobotProvider extends RobotProvider {
 
     private PneumaticHub ph = new PneumaticHub();
 
+    private static String getStringOrEmpty(ValueProvider<String> string) {
+        return string.hasValue() ? string.get() : "";
+    }
+
     @Override
     public MotorController getMotor(
             final int index,
@@ -141,7 +145,7 @@ public class WPIRobotProvider extends RobotProvider {
             case TalonFX:
                 final ValueProvider<String> canBus =
                         ConfigFileReader.getInstance().getString(configPrefix + ".CANBus");
-                motor = new CANTalonFxMotorController(index, canBus.hasValue() ? canBus.get() : "");
+                motor = new CANTalonFxMotorController(index, getStringOrEmpty(canBus));
                 break;
             case VictorSP:
                 motor = new LocalMotorController(configPrefix, new PWMVictorSP(index), localSensor);
@@ -195,7 +199,7 @@ public class WPIRobotProvider extends RobotProvider {
             if (type.get() == GyroReader.Type.Pigeon2) {
                 ValueProvider<String> canBus =
                         ConfigFileReader.getInstance().getString(configPrefix + ".CANBus");
-                return new PigeonGyro(index, canBus.hasValue() ? canBus.get() : "");
+                return new PigeonGyro(index, getStringOrEmpty(canBus));
             }
         }
 


### PR DESCRIPTION
## Description

Currently, if a CANbus property is not specified (eg left as the default of `null`), that can cause issues with CTRE code finding those devices.  CTRE treats `""` as the default CAN bus.  This change simply passes `""` for the CAN bus if not set.

## How Has This Been Tested?

Will test on SwerveAndShoot during the week.
