### PR TITLE
fix Drive.setCross() merge issue

### DIFF
--- a/src/main/java/com/team766/robot/common/mechanisms/Drive.java
+++ b/src/main/java/com/team766/robot/common/mechanisms/Drive.java
@@ -182,18 +182,10 @@ public class Drive extends Mechanism {
     public void setCross() {
         checkContextOwnership();
 
-        // TODO: use createOrthogonalVector?
-        swerveFL.steer(
-                new Vector2D(
-                        config.frontLeftLocation().getY(), -config.frontLeftLocation().getX()));
-        swerveFR.steer(
-                new Vector2D(
-                        config.frontRightLocation().getY(), -config.frontRightLocation().getX()));
-        swerveBL.steer(
-                new Vector2D(config.backLeftLocation().getY(), -config.backLeftLocation().getX()));
-        swerveBR.steer(
-                new Vector2D(
-                        config.backRightLocation().getY(), -config.backRightLocation().getX()));
+        swerveFL.steer(config.frontLeftLocation());
+        swerveFR.steer(config.frontRightLocation());
+        swerveBL.steer(config.backLeftLocation());
+        swerveBR.steer(config.backRightLocation());
     }
 
     public void resetGyro() {


### PR DESCRIPTION
## Description

Drive.setCross() was not merged correctly during recent changes.  The same module is incorrectly being steered during setCross().  This PR fixes the typos.

## How Has This Been Tested?

Need to test on Gatorade.

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
