### PR TITLE
switch from encoder units to rotations, as per phoenix 6 APIs

### DIFF
--- a/src/main/java/com/team766/robot/common/mechanisms/SwerveModule.java
+++ b/src/main/java/com/team766/robot/common/mechanisms/SwerveModule.java
@@ -28,7 +28,7 @@ public class SwerveModule {
      * Divide to convert from motor units to degrees
      */
     private static final double ENCODER_CONVERSION_FACTOR =
-            (150.0 / 7.0) /*steering gear ratio*/ * (2048.0 / 360.0) /*encoder units to degrees*/;
+            (150.0 / 7.0) /*steering gear ratio*/ * (1 / 360.0) /*rotations to degrees*/;
 
     /**
      * Creates a new SwerveModule.

--- a/src/main/java/com/team766/robot/gatorade/constants/OdometryInputConstants.java
+++ b/src/main/java/com/team766/robot/gatorade/constants/OdometryInputConstants.java
@@ -13,8 +13,8 @@ public final class OdometryInputConstants {
     // to wheel revolutions.
     public static final double GEAR_RATIO = 6.75;
     // Unique to the type of swerve module we have. For every revolution of the wheel, the encoders
-    // will increase by 2048.
-    public static final int ENCODER_TO_REVOLUTION_CONSTANT = 2048;
+    // will increase by 1.
+    public static final int ENCODER_TO_REVOLUTION_CONSTANT = 1;
     // The distance between the centers of the wheels on each side of the robot. This was measured
     // as 20.5 inches, then converted to meters.
     public static final double DISTANCE_BETWEEN_WHEELS = 20.5 * 2.54 / 100;


### PR DESCRIPTION
## Description

Phoenix 6 has moved to rotations.  Switch the relevant computations in our code from encoder units to rotations.

## How Has This Been Tested?

Requires testing.

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
