### PR TITLE
add support for reading, setting PID from motor config

### DIFF
--- a/src/main/java/com/team766/controllers/PIDController.java
+++ b/src/main/java/com/team766/controllers/PIDController.java
@@ -28,6 +28,15 @@ import com.team766.logging.Severity;
  *
  */
 public class PIDController {
+
+    public static final String P_GAIN_KEY = "pGain";
+    public static final String I_GAIN_KEY = "iGain";
+    public static final String D_GAIN_KEY = "dGain";
+    public static final String FF_GAIN_KEY = "ffGain";
+    public static final String OUTPUT_MAX_LOW_KEY = "outputMaxLow";
+    public static final String OUTPUT_MAX_HIGH_KEY = "outputMaxHigh";
+    public static final String THRESHOLD_KEY = "threshold";
+
     private int printCounter = 0;
     private boolean print = false;
 
@@ -58,13 +67,13 @@ public class PIDController {
             configPrefix += ".";
         }
         return new PIDController(
-                ConfigFileReader.getInstance().getDouble(configPrefix + "pGain"),
-                ConfigFileReader.getInstance().getDouble(configPrefix + "iGain"),
-                ConfigFileReader.getInstance().getDouble(configPrefix + "dGain"),
-                ConfigFileReader.getInstance().getDouble(configPrefix + "ffGain"),
-                ConfigFileReader.getInstance().getDouble(configPrefix + "outputMaxLow"),
-                ConfigFileReader.getInstance().getDouble(configPrefix + "outputMaxHigh"),
-                ConfigFileReader.getInstance().getDouble(configPrefix + "threshold"));
+                ConfigFileReader.getInstance().getDouble(configPrefix + P_GAIN_KEY),
+                ConfigFileReader.getInstance().getDouble(configPrefix + I_GAIN_KEY),
+                ConfigFileReader.getInstance().getDouble(configPrefix + D_GAIN_KEY),
+                ConfigFileReader.getInstance().getDouble(configPrefix + FF_GAIN_KEY),
+                ConfigFileReader.getInstance().getDouble(configPrefix + OUTPUT_MAX_LOW_KEY),
+                ConfigFileReader.getInstance().getDouble(configPrefix + OUTPUT_MAX_HIGH_KEY),
+                ConfigFileReader.getInstance().getDouble(configPrefix + THRESHOLD_KEY));
     }
 
     /**

--- a/src/main/java/com/team766/hal/RobotProvider.java
+++ b/src/main/java/com/team766/hal/RobotProvider.java
@@ -1,6 +1,7 @@
 package com.team766.hal;
 
 import com.team766.config.ConfigFileReader;
+import com.team766.controllers.PIDController;
 import com.team766.controllers.TimeProviderI;
 import com.team766.hal.mock.MockAnalogInput;
 import com.team766.hal.mock.MockDigitalInput;
@@ -164,17 +165,23 @@ public abstract class RobotProvider {
 
     private void configurePID(final String configName, MotorController motor) {
         ValueProvider<Double> pValue =
-                ConfigFileReader.getInstance().getDouble(configName + ".pid.pGain");
+                ConfigFileReader.getInstance()
+                        .getDouble(configName + ".pid." + PIDController.P_GAIN_KEY);
         ValueProvider<Double> iValue =
-                ConfigFileReader.getInstance().getDouble(configName + ".pid.iGain");
+                ConfigFileReader.getInstance()
+                        .getDouble(configName + ".pid." + PIDController.I_GAIN_KEY);
         ValueProvider<Double> dValue =
-                ConfigFileReader.getInstance().getDouble(configName + ".pid.dGain");
+                ConfigFileReader.getInstance()
+                        .getDouble(configName + ".pid." + PIDController.D_GAIN_KEY);
         ValueProvider<Double> ffValue =
-                ConfigFileReader.getInstance().getDouble(configName + ".pid.ffGain");
+                ConfigFileReader.getInstance()
+                        .getDouble(configName + ".pid." + PIDController.FF_GAIN_KEY);
         ValueProvider<Double> outputMaxLowValue =
-                ConfigFileReader.getInstance().getDouble(configName + ".pid.outputMaxLow");
+                ConfigFileReader.getInstance()
+                        .getDouble(configName + ".pid." + PIDController.OUTPUT_MAX_LOW_KEY);
         ValueProvider<Double> outputMaxHighValue =
-                ConfigFileReader.getInstance().getDouble(configName + ".pid.outputMaxHigh");
+                ConfigFileReader.getInstance()
+                        .getDouble(configName + ".pid." + PIDController.OUTPUT_MAX_HIGH_KEY);
         // TODO: also handle .threshold?
 
         if (pValue.hasValue()) {
@@ -194,7 +201,7 @@ public abstract class RobotProvider {
         }
 
         if (outputMaxLowValue.hasValue() || outputMaxHighValue.hasValue()) {
-            motor.setOutputRange(outputMaxLowValue.valueOr(0.0), outputMaxHighValue.valueOr(0.0));
+            motor.setOutputRange(outputMaxLowValue.valueOr(-1.0), outputMaxHighValue.valueOr(1.0));
         }
     }
 


### PR DESCRIPTION
## Description

MaroonFramework's config support (in `RobotProvider`) only read and set PID for local motor controllers.  This PR adds support to read and set PID (P, I, D, FF output range) from the config file and setting the provided values on the motor controller.


## How Has This Been Tested?

Needs to be tested on Gatorade.

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
