### PR TITLE
adds a Math.interpolate utility method

### DIFF
--- a/src/main/java/com/team766/math/Math.java
+++ b/src/main/java/com/team766/math/Math.java
@@ -77,11 +77,12 @@ public class Math {
         }
 
         // interpolate
-        double x0 = xGetter.apply(data[index - 1]);
-        double y0 = yGetter.apply(data[index - 1]);
-        double y1 = yGetter.apply(data[index]);
+        final double x0 = xGetter.apply(data[index - 1]);
+        final double y0 = yGetter.apply(data[index - 1]);
+        final double y1 = yGetter.apply(data[index]);
 
-        double slope = (y1 - y0) / (x1 - x0);
+        final double slope = (y1 - y0) / (x1 - x0);
+
         return y0 + (targetX - x0) * slope;
     }
 }

--- a/src/test/java/com/team766/math/MathTest.java
+++ b/src/test/java/com/team766/math/MathTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 public class MathTest {
 
     private record TestData(double x, double y) {}
-    ;
 
     @Test
     public void testInterpolateEmpty() {
@@ -53,8 +52,10 @@ public class MathTest {
                     new TestData(10.0, 100.0)
                 };
 
+        assertEquals(0.0, Math.interpolate(data, 0.0, TestData::x, TestData::y));
         assertEquals(25.0, Math.interpolate(data, 2.5, TestData::x, TestData::y));
         assertEquals(50.0, Math.interpolate(data, 5.0, TestData::x, TestData::y));
+        assertEquals(100.0, Math.interpolate(data, 10.0, TestData::x, TestData::y));
     }
 
     @Test


### PR DESCRIPTION
## Description

Adds a`Math.interpolate` utility method.  Makes it easy to interpolate `y` values in an
array of data.

Example usage:

      public record Data(double x, double y);
      ...
      Data[] data = new Data[] { new Data(0.0, 1.0), new Data(1.0, 32.0), ... };
      Math.interpolate(data, 0.5, Data::x, Data::y);

## How Has This Been Tested?

Added unit test for code.

- [x] Unit tests: Tests empty, below range, above range, exact match, within range cases.
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
