### PR TITLE
Add code to get just the tag with a correct tag ID

### DIFF
--- a/src/main/java/com/team766/ViSIONbase/GrayScaleCamera.java
+++ b/src/main/java/com/team766/ViSIONbase/GrayScaleCamera.java
@@ -61,10 +61,10 @@ public class GrayScaleCamera extends PhotonCamera {
         }
     }
 
-    public PhotonTrackedTarget getTrackedTargetWithID(int ID) throws AprilTagGeneralCheckedException {
+    public PhotonTrackedTarget getTrackedTargetWithID(int ID)
+            throws AprilTagGeneralCheckedException {
         var result = getLatestResult();
-        boolean hasTargets =
-                result.hasTargets();
+        boolean hasTargets = result.hasTargets();
         if (hasTargets) {
             List<PhotonTrackedTarget> targets = result.getTargets(); // getting targets
 
@@ -74,7 +74,8 @@ public class GrayScaleCamera extends PhotonCamera {
                 }
             }
 
-            throw new AprilTagGeneralCheckedException("No target with the desired ID of " + ID + " was found by the camera.");
+            throw new AprilTagGeneralCheckedException(
+                    "No target with the desired ID of " + ID + " was found by the camera.");
         } else {
             throw new AprilTagGeneralCheckedException(
                     "There were no targets that could be picked up by the camera.");


### PR DESCRIPTION
## Description

Code adds a method to the GrayScaleCamera class that iterates through the PhotonTrackedTarget list looking for only the specified tag ID. It either then returns this tag or returns an error.

## How Has This Been Tested?

PhotonVision discord approves of this method (I asked the photonvision gods there).