### PR TITLE
Remove device object cache so there aren't CAN id conflicts

### DIFF
--- a/src/main/java/com/team766/hal/RobotProvider.java
+++ b/src/main/java/com/team766/hal/RobotProvider.java
@@ -21,17 +21,6 @@ public abstract class RobotProvider {
 
     public static RobotProvider instance;
 
-    protected EncoderReader[] encoders = new EncoderReader[20];
-    protected SolenoidController[] solenoids = new SolenoidController[20];
-    protected GyroReader[] gyros = new GyroReader[13];
-    protected HashMap<String, CameraReader> cams = new HashMap<String, CameraReader>();
-    protected JoystickReader[] joysticks = new JoystickReader[8];
-    protected DigitalInputReader[] digInputs = new DigitalInputReader[8];
-    protected AnalogInputReader[] angInputs = new AnalogInputReader[5];
-    protected RelayOutput[] relays = new RelayOutput[5];
-    protected PositionReader positionSensor = null;
-    protected BeaconReader beaconSensor = null;
-
     private HashMap<Integer, String> motorDeviceIdNames = new HashMap<Integer, String>();
     private HashMap<Integer, String> motorPortNames = new HashMap<Integer, String>();
     private HashMap<Integer, String> digitalIoNames = new HashMap<Integer, String>();

--- a/src/main/java/com/team766/hal/mock/TestRobotProvider.java
+++ b/src/main/java/com/team766/hal/mock/TestRobotProvider.java
@@ -42,10 +42,7 @@ public class TestRobotProvider extends RobotProvider {
 
     @Override
     public EncoderReader getEncoder(final int index1, final int index2) {
-        if (encoders[index1] == null) {
-            encoders[index1] = new MockEncoder();
-        }
-        return encoders[index1];
+        return new MockEncoder();
     }
 
     @Override
@@ -55,42 +52,27 @@ public class TestRobotProvider extends RobotProvider {
 
     @Override
     public SolenoidController getSolenoid(final int index) {
-        if (solenoids[index] == null) {
-            solenoids[index] = new MockSolenoid(index);
-        }
-        return solenoids[index];
+        return new MockSolenoid(index);
     }
 
     @Override
     public GyroReader getGyro(final int index, String configPrefix) {
-        if (gyros[0] == null) {
-            gyros[0] = new MockGyro();
-        }
-        return gyros[0];
+        return new MockGyro();
     }
 
     @Override
     public CameraReader getCamera(final String id, final String value) {
-        if (!cams.containsKey(id)) {
-            cams.put(id, new MockCamera());
-        }
-        return cams.get(id);
+        return new MockCamera();
     }
 
     @Override
     public JoystickReader getJoystick(final int index) {
-        if (joysticks[index] == null) {
-            joysticks[index] = new MockJoystick();
-        }
-        return joysticks[index];
+        return new MockJoystick();
     }
 
     @Override
     public DigitalInputReader getDigitalInput(final int index) {
-        if (digInputs[index] == null) {
-            digInputs[index] = new MockDigitalInput();
-        }
-        return digInputs[index];
+        return new MockDigitalInput();
     }
 
     @Override
@@ -100,33 +82,21 @@ public class TestRobotProvider extends RobotProvider {
 
     @Override
     public AnalogInputReader getAnalogInput(final int index) {
-        if (angInputs[index] == null) {
-            angInputs[index] = new MockAnalogInput();
-        }
-        return angInputs[index];
+        return new MockAnalogInput();
     }
 
     public RelayOutput getRelay(final int index) {
-        if (relays[index] == null) {
-            relays[index] = new MockRelay(index);
-        }
-        return relays[index];
+        return new MockRelay(index);
     }
 
     @Override
     public PositionReader getPositionSensor() {
-        if (positionSensor == null) {
-            positionSensor = new MockPositionSensor();
-        }
-        return positionSensor;
+        return new MockPositionSensor();
     }
 
     @Override
     public BeaconReader getBeaconSensor() {
-        if (beaconSensor == null) {
-            beaconSensor = new MockBeaconSensor();
-        }
-        return beaconSensor;
+        return new MockBeaconSensor();
     }
 
     @Override

--- a/src/main/java/com/team766/hal/simulator/SimulationRobotProvider.java
+++ b/src/main/java/com/team766/hal/simulator/SimulationRobotProvider.java
@@ -43,42 +43,27 @@ public class SimulationRobotProvider extends RobotProvider {
 
     @Override
     public EncoderReader getEncoder(final int index1, final int index2) {
-        if (encoders[index1] == null) {
-            encoders[index1] = new Encoder(index1);
-        }
-        return encoders[index1];
+        return new Encoder(index1);
     }
 
     @Override
     public EncoderReader getEncoder(final int index1, String configPrefix) {
-        if (encoders[index1] == null) {
-            encoders[index1] = new Encoder(index1);
-        }
-        return encoders[index1];
+        return new Encoder(index1);
     }
 
     @Override
     public SolenoidController getSolenoid(final int index) {
-        if (solenoids[index] == null) {
-            solenoids[index] = new Solenoid(index);
-        }
-        return solenoids[index];
+        return new Solenoid(index);
     }
 
     @Override
     public GyroReader getGyro(final int index, String configPrefix) {
-        if (gyros[0] == null) {
-            gyros[0] = new Gyro();
-        }
-        return gyros[0];
+        return new Gyro();
     }
 
     @Override
     public CameraReader getCamera(final String id, final String value) {
-        if (!cams.containsKey(id)) {
-            cams.put(id, new Camera());
-        }
-        return cams.get(id);
+        return new Camera();
     }
 
     @Override
@@ -88,10 +73,7 @@ public class SimulationRobotProvider extends RobotProvider {
 
     @Override
     public DigitalInputReader getDigitalInput(final int index) {
-        if (digInputs[index] == null) {
-            digInputs[index] = new DigitalInput(index);
-        }
-        return digInputs[index];
+        return new DigitalInput(index);
     }
 
     @Override
@@ -101,33 +83,21 @@ public class SimulationRobotProvider extends RobotProvider {
 
     @Override
     public AnalogInputReader getAnalogInput(final int index) {
-        if (angInputs[index] == null) {
-            angInputs[index] = new AnalogInput(index);
-        }
-        return angInputs[index];
+        return new AnalogInput(index);
     }
 
     public RelayOutput getRelay(final int index) {
-        if (relays[index] == null) {
-            relays[index] = new Relay(index);
-        }
-        return relays[index];
+        return new Relay(index);
     }
 
     @Override
     public PositionReader getPositionSensor() {
-        if (positionSensor == null) {
-            positionSensor = new PositionSensor();
-        }
-        return positionSensor;
+        return new PositionSensor();
     }
 
     @Override
     public BeaconReader getBeaconSensor() {
-        if (beaconSensor == null) {
-            beaconSensor = new BeaconSensor();
-        }
-        return beaconSensor;
+        return new BeaconSensor();
     }
 
     @Override

--- a/src/main/java/com/team766/hal/wpilib/WPIRobotProvider.java
+++ b/src/main/java/com/team766/hal/wpilib/WPIRobotProvider.java
@@ -172,10 +172,7 @@ public class WPIRobotProvider extends RobotProvider {
 
     @Override
     public EncoderReader getEncoder(int index1, int index2) {
-        if (encoders[index1] == null) {
-            encoders[index1] = new Encoder(index1, index2);
-        }
-        return encoders[index1];
+        return new Encoder(index1, index2);
     }
 
     @Override
@@ -210,10 +207,7 @@ public class WPIRobotProvider extends RobotProvider {
 
     @Override
     public SolenoidController getSolenoid(int index) {
-        if (solenoids[index] == null) {
-            solenoids[index] = new Solenoid(index);
-        }
-        return solenoids[index];
+        return new Solenoid(index);
     }
 
     @Override
@@ -234,24 +228,21 @@ public class WPIRobotProvider extends RobotProvider {
             }
         }
 
-        if (gyros[index + 2] == null) {
-            if (index < -2) {
-                Logger.get(Category.CONFIGURATION)
-                        .logRaw(
-                                Severity.ERROR,
-                                "Invalid gyro port "
-                                        + index
-                                        + ". Must be -2, -1, or a non-negative integer");
-                return new MockGyro();
-            } else if (index == -2) {
-                gyros[index + 2] = new NavXGyro(I2C.Port.kOnboard);
-            } else if (index == -1) {
-                gyros[index + 2] = new ADXRS450_Gyro(SPI.Port.kOnboardCS0);
-            } else {
-                gyros[index + 2] = new AnalogGyro(index);
-            }
+        if (index < -2) {
+            Logger.get(Category.CONFIGURATION)
+                    .logRaw(
+                            Severity.ERROR,
+                            "Invalid gyro port "
+                                    + index
+                                    + ". Must be -2, -1, or a non-negative integer");
+            return new MockGyro();
+        } else if (index == -2) {
+            return new NavXGyro(I2C.Port.kOnboard);
+        } else if (index == -1) {
+            return new ADXRS450_Gyro(SPI.Port.kOnboardCS0);
+        } else {
+            return new AnalogGyro(index);
         }
-        return gyros[index + 2];
     }
 
     @Override
@@ -262,10 +253,7 @@ public class WPIRobotProvider extends RobotProvider {
 
     @Override
     public JoystickReader getJoystick(int index) {
-        if (joysticks[index] == null) {
-            joysticks[index] = new Joystick(index);
-        }
-        return joysticks[index];
+        return new Joystick(index);
     }
 
     @Override
@@ -275,50 +263,35 @@ public class WPIRobotProvider extends RobotProvider {
 
     @Override
     public DigitalInputReader getDigitalInput(final int index) {
-        if (digInputs[index] == null) {
-            digInputs[index] = new DigitalInput(index);
-        }
-        return digInputs[index];
+        return new DigitalInput(index);
     }
 
     @Override
     public AnalogInputReader getAnalogInput(int index) {
-        if (angInputs[index] == null) {
-            angInputs[index] = new AnalogInput(index);
-        }
-        return angInputs[index];
+        return new AnalogInput(index);
     }
 
     @Override
     public RelayOutput getRelay(int index) {
-        if (relays[index] == null) {
-            relays[index] = new Relay(index);
-        }
-        return relays[index];
+        return new Relay(index);
     }
 
     @Override
     public PositionReader getPositionSensor() {
-        if (positionSensor == null) {
-            positionSensor = new MockPositionSensor();
-            Logger.get(Category.CONFIGURATION)
-                    .logRaw(
-                            Severity.ERROR,
-                            "Position sensor does not exist on real robots. Using mock position sensor instead - it will always return a position of 0");
-        }
-        return positionSensor;
+        Logger.get(Category.CONFIGURATION)
+                .logRaw(
+                        Severity.ERROR,
+                        "Position sensor does not exist on real robots. Using mock position sensor instead - it will always return a position of 0");
+        return new MockPositionSensor();
     }
 
     @Override
     public BeaconReader getBeaconSensor() {
-        if (beaconSensor == null) {
-            beaconSensor = new MockBeaconSensor();
-            Logger.get(Category.CONFIGURATION)
-                    .logRaw(
-                            Severity.ERROR,
-                            "Beacon sensor does not exist on real robots. Using mock beacon sensor instead - it will always return no beacons");
-        }
-        return beaconSensor;
+        Logger.get(Category.CONFIGURATION)
+                .logRaw(
+                        Severity.ERROR,
+                        "Beacon sensor does not exist on real robots. Using mock beacon sensor instead - it will always return no beacons");
+        return new MockBeaconSensor();
     }
 
     @Override


### PR DESCRIPTION
## Description

PR written by @rcahoon 

We previously had a map from device ID to device object; the map entry is populated the first time that the device with that ID is requested. This allowed e.g. `getMotor` to be called multiple times and return the same object. This made more sense with software architecture that we used many years ago, but now we ask for each device exactly once in the appropriate `Mechanism`.

This is now causing problems because it means we can only have one motor with each ID. We now have enough motors of different types that we're out of IDs if we can only have 64 of any motor. We would be ok if we can have 64 of each motor type, which is permitted by the FRC device ID standard.

Thus, we remove the device object maps from the Maroon Framework. The device object will be (re)created when the appropriate method of `RobotProvider` is called.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Be detailed so that your code reviewer can understand exactly how much and what kinds of testing were done, and which might still be worthwhile to do.

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
