### PR TITLE
undo CANTalonFxMotorController VelocityVoltage change

### DIFF
--- a/src/main/java/com/team766/hal/wpilib/CANTalonFxMotorController.java
+++ b/src/main/java/com/team766/hal/wpilib/CANTalonFxMotorController.java
@@ -12,7 +12,7 @@ import com.ctre.phoenix6.configs.TalonFXConfigurator;
 import com.ctre.phoenix6.controls.DutyCycleOut;
 import com.ctre.phoenix6.controls.PositionDutyCycle;
 import com.ctre.phoenix6.controls.StrictFollower;
-import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.controls.VelocityDutyCycle;
 import com.ctre.phoenix6.controls.VoltageOut;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.hardware.TalonFX;
@@ -80,7 +80,7 @@ public class CANTalonFxMotorController extends TalonFX implements MotorControlle
                 super.setControl(position);
                 break;
             case Velocity:
-                VelocityVoltage velocity = new VelocityVoltage(value);
+                VelocityDutyCycle velocity = new VelocityDutyCycle(value);
                 super.setControl(velocity);
                 break;
             case Voltage:


### PR DESCRIPTION
## Description

Undo VelocityVoltage change until we are ready to retune PID

## How Has This Been Tested?

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
