### PR TITLE
Fix LoggerTest on Windows

### DIFF
--- a/src/main/java/com/team766/logging/LogReader.java
+++ b/src/main/java/com/team766/logging/LogReader.java
@@ -1,51 +1,55 @@
 package com.team766.logging;
 
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.ExtensionRegistryLite;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import com.google.protobuf.CodedInputStream;
-import com.google.protobuf.ExtensionRegistryLite;
 
 public class LogReader {
 
-	private FileInputStream m_fileStream;
-	private CodedInputStream m_dataStream;
-	private LogEntry.Builder m_entryBuilder;
-	private ArrayList<String> m_formatStrings;
+    private FileInputStream m_fileStream;
+    private CodedInputStream m_dataStream;
+    private LogEntry.Builder m_entryBuilder;
+    private ArrayList<String> m_formatStrings;
 
-	public LogReader(final String filename) throws IOException {
-		m_fileStream = new FileInputStream(filename);
-		m_dataStream = CodedInputStream.newInstance(m_fileStream);
-		m_entryBuilder = LogEntry.newBuilder();
-		m_formatStrings = new ArrayList<String>();
-	}
+    public LogReader(final String filename) throws IOException {
+        m_fileStream = new FileInputStream(filename);
+        m_dataStream = CodedInputStream.newInstance(m_fileStream);
+        m_entryBuilder = LogEntry.newBuilder();
+        m_formatStrings = new ArrayList<String>();
+    }
 
-	public LogEntry readNext() throws IOException {
-		m_entryBuilder.clear();
-		m_dataStream.readMessage(m_entryBuilder, ExtensionRegistryLite.getEmptyRegistry());
-		LogEntry entry = m_entryBuilder.build();
-		if (entry.hasMessageIndex() && entry.hasMessageStr()) {
-			final int index = entry.getMessageIndex();
-			final String format = entry.getMessageStr();
-			m_formatStrings.ensureCapacity(index + 1);
-			while (m_formatStrings.size() <= index) {
-				m_formatStrings.add(null);
-			}
-			m_formatStrings.set(index, format);
-		}
-		return entry;
-	}
+    public void close() throws IOException {
+        m_fileStream.close();
+    }
 
-	String getFormatString(final int index) {
-		String str;
-		try {
-			str = m_formatStrings.get(index);
-		} catch (IndexOutOfBoundsException ex) {
-			throw new IllegalArgumentException("Unknown format string index: " + index);
-		}
-		if (str == null) {
-			throw new IllegalArgumentException("Unknown format string index: " + index);
-		}
-		return str;
-	}
+    public LogEntry readNext() throws IOException {
+        m_entryBuilder.clear();
+        m_dataStream.readMessage(m_entryBuilder, ExtensionRegistryLite.getEmptyRegistry());
+        LogEntry entry = m_entryBuilder.build();
+        if (entry.hasMessageIndex() && entry.hasMessageStr()) {
+            final int index = entry.getMessageIndex();
+            final String format = entry.getMessageStr();
+            m_formatStrings.ensureCapacity(index + 1);
+            while (m_formatStrings.size() <= index) {
+                m_formatStrings.add(null);
+            }
+            m_formatStrings.set(index, format);
+        }
+        return entry;
+    }
+
+    String getFormatString(final int index) {
+        String str;
+        try {
+            str = m_formatStrings.get(index);
+        } catch (IndexOutOfBoundsException ex) {
+            throw new IllegalArgumentException("Unknown format string index: " + index);
+        }
+        if (str == null) {
+            throw new IllegalArgumentException("Unknown format string index: " + index);
+        }
+        return str;
+    }
 }

--- a/src/test/java/com/team766/logging/LoggerTest.java
+++ b/src/test/java/com/team766/logging/LoggerTest.java
@@ -48,6 +48,7 @@ public class LoggerTest {
         assertEquals("num: 63 str: second blurb", logString2);
         String logString3 = LogEntryRenderer.renderLogEntry(reader.readNext(), reader);
         assertEquals("Test raw log", logString3);
+        reader.close();
     }
 
     @Test


### PR DESCRIPTION
## Description

There is a known issue where TempDir fails to delete if there are any file handles still open in the directory. It appears that the `LogReader` object is not garbage collected quickly enough to close its file handles implicitly, so we need to explicitly close it.

https://github.com/junit-team/junit5/issues/2811#issuecomment-1703476137

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Be detailed so that your code reviewer can understand exactly how much and what kinds of testing were done, and which might still be worthwhile to do.

- [X] Unit tests: Ran LoggerTest on a Windows machine and it now passes
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
