### PR TITLE
clean up common DriverOI

### DIFF
--- a/src/main/java/com/team766/robot/common/DriverOI.java
+++ b/src/main/java/com/team766/robot/common/DriverOI.java
@@ -37,8 +37,8 @@ public class DriverOI extends OIFragment {
                                                 > 0);
     }
 
-    public void handleOI(Context context) {
-
+    @Override
+    protected void handlePre() {
         // Negative because forward is negative in driver station
         leftJoystickX =
                 -createJoystickDeadzone(leftJoystick.getAxis(InputConstants.AXIS_FORWARD_BACKWARD))
@@ -51,7 +51,10 @@ public class DriverOI extends OIFragment {
         rightJoystickY =
                 -createJoystickDeadzone(rightJoystick.getAxis(InputConstants.AXIS_LEFT_RIGHT))
                         * ControlConstants.MAX_ROTATIONAL_VELOCITY; // For steer
+    }
 
+    @Override
+    protected void handleOI(Context context) {
         if (leftJoystick.getButtonPressed(InputConstants.BUTTON_RESET_GYRO)) {
             drive.resetGyro();
         }


### PR DESCRIPTION
## Description

Fix some changes I missed from the version of this in the original branch introducing `OIFragment`:
- `DriverOI` should update several member variables (`leftJoystickX`, etc) in `handlePre` vs `handleOI`.
- `handleOI` should be protected 

## How Has This Been Tested?

Needs testing on RevA.

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
