### PR TITLE
Add runSync to Context for symmetry with startAsync

### DIFF
--- a/src/main/java/com/team766/framework/Context.java
+++ b/src/main/java/com/team766/framework/Context.java
@@ -99,6 +99,12 @@ public interface Context {
     LaunchedContext startAsync(final Runnable func);
 
     /**
+     * Run the given Procedure synchronously (the calling Procedure will not resume until this one
+     * has finished).
+     */
+    void runSync(final RunnableWithContext func);
+
+    /**
      * Take ownership of the given Mechanism with this Context.
      *
      * Only one Context can own a Mechanism at one time. If any Context previously owned this

--- a/src/main/java/com/team766/framework/ContextImpl.java
+++ b/src/main/java/com/team766/framework/ContextImpl.java
@@ -421,6 +421,11 @@ class ContextImpl<T> implements Runnable, ContextWithValue<T>, LaunchedContextWi
         return new ContextImpl<>(func, this);
     }
 
+    @Override
+    public void runSync(final RunnableWithContext func) {
+        func.run(this);
+    }
+
     /**
      * Interrupt the running of this Context and force it to terminate.
      *

--- a/src/main/java/com/team766/robot/common/procedures/PathSequenceAuto.java
+++ b/src/main/java/com/team766/robot/common/procedures/PathSequenceAuto.java
@@ -116,7 +116,7 @@ public class PathSequenceAuto extends Procedure {
                                 : initialPosition.getRotation())
                         .getDegrees());
         for (RunnableWithContext pathItem : pathItems) {
-            pathItem.run(context);
+            context.runSync(pathItem);
             context.yield();
         }
 

--- a/src/main/java/com/team766/robot/gatorade/OI.java
+++ b/src/main/java/com/team766/robot/gatorade/OI.java
@@ -65,20 +65,20 @@ public class OI extends Procedure {
             driverOI.handleOI(context);
 
             if (leftJoystick.getButtonPressed(InputConstants.INTAKE_OUT)) {
-                new IntakeOut().run(context);
+                context.runSync(new IntakeOut());
             } else if (leftJoystick.getButtonReleased(InputConstants.INTAKE_OUT)) {
-                new IntakeStop().run(context);
+                context.runSync(new IntakeStop());
             }
 
             // Respond to boxop commands
 
             // first, check if the boxop is making a cone or cube selection
             if (boxopGamepad.getPOV() == InputConstants.POV_UP) {
-                new GoForCones().run(context);
+                context.runSync(new GoForCones());
                 setLightsForGamePiece();
                 SmartDashboard.putBoolean("Game Piece", true);
             } else if (boxopGamepad.getPOV() == InputConstants.POV_DOWN) {
-                new GoForCubes().run(context);
+                context.runSync(new GoForCubes());
                 setLightsForGamePiece();
                 SmartDashboard.putBoolean("Game Piece", false);
             }
@@ -103,11 +103,11 @@ public class OI extends Procedure {
 
             // look for button hold to start intake, release to idle intake
             if (boxopGamepad.getButtonPressed(InputConstants.BUTTON_INTAKE_IN)) {
-                new IntakeIn().run(context);
+                context.runSync(new IntakeIn());
             } else if (boxopGamepad.getButtonReleased(InputConstants.BUTTON_INTAKE_IN)) {
-                new IntakeIdle().run(context);
+                context.runSync(new IntakeIdle());
             } else if (boxopGamepad.getButton(InputConstants.BUTTON_INTAKE_STOP)) {
-                new IntakeStop().run(context);
+                context.runSync(new IntakeStop());
             }
 
             // look for button hold to extend intake/wrist/elevator superstructure,

--- a/src/main/java/com/team766/robot/gatorade/procedures/ExtendToHumanWithIntake.java
+++ b/src/main/java/com/team766/robot/gatorade/procedures/ExtendToHumanWithIntake.java
@@ -17,7 +17,7 @@ public class ExtendToHumanWithIntake extends Procedure {
         context.takeOwnership(Robot.wrist);
         context.takeOwnership(Robot.elevator);
 
-        new IntakeIn().run(context);
-        new ExtendWristvatorToHuman(gamePieceType).run(context);
+        context.runSync(new IntakeIn());
+        context.runSync(new ExtendWristvatorToHuman(gamePieceType));
     }
 }

--- a/src/main/java/com/team766/robot/gatorade/procedures/GyroBalance.java
+++ b/src/main/java/com/team766/robot/gatorade/procedures/GyroBalance.java
@@ -73,7 +73,7 @@ public class GyroBalance extends Procedure {
         double driveSpeed = 1;
 
         // extend wristvator to put CG in a place where robot can climb ramp
-        new ExtendWristvatorToMid().run(context);
+        context.runSync(new ExtendWristvatorToMid());
 
         // Sets movement direction ground state if on ground
         setDir(curY);

--- a/src/main/java/com/team766/robot/gatorade/procedures/OPECHelper.java
+++ b/src/main/java/com/team766/robot/gatorade/procedures/OPECHelper.java
@@ -15,7 +15,7 @@ public class OPECHelper extends Procedure {
         double startY = Robot.drive.getCurrentPosition().getY();
         // robot gyro is offset 90º from how we want, so we reset it to 90º to account for this
         Robot.drive.resetGyro();
-        // new IntakeRelease().run(context);
+        // context.runSync(new IntakeRelease());
         Robot.drive.controlFieldOriented(0, -FollowPointsInputConstants.SPEED, 0);
         context.waitFor(() -> Math.abs(Robot.drive.getCurrentPosition().getY() - startY) > DIST);
         Robot.drive.stopDrive();

--- a/src/main/java/com/team766/robot/gatorade/procedures/OnePieceBalance.java
+++ b/src/main/java/com/team766/robot/gatorade/procedures/OnePieceBalance.java
@@ -40,7 +40,7 @@ public class OnePieceBalance extends Procedure {
             log("invalid alliance");
             return;
         }
-        new ScoreHigh(type).run(context);
-        new GyroBalance(alliance.get()).run(context);
+        context.runSync(new ScoreHigh(type));
+        context.runSync(new GyroBalance(alliance.get()));
     }
 }

--- a/src/main/java/com/team766/robot/gatorade/procedures/OnePieceExitCommunity.java
+++ b/src/main/java/com/team766/robot/gatorade/procedures/OnePieceExitCommunity.java
@@ -41,8 +41,8 @@ public class OnePieceExitCommunity extends Procedure {
             return;
         }
         log("exiting");
-        new ScoreHigh(type).run(context);
-        new RetractWristvator().run(context);
-        new ExitCommunity().run(context);
+        context.runSync(new ScoreHigh(type));
+        context.runSync(new RetractWristvator());
+        context.runSync(new ExitCommunity());
     }
 }

--- a/src/main/java/com/team766/robot/gatorade/procedures/OnePieceExitCommunityBalance.java
+++ b/src/main/java/com/team766/robot/gatorade/procedures/OnePieceExitCommunityBalance.java
@@ -41,9 +41,9 @@ public class OnePieceExitCommunityBalance extends Procedure {
             return;
         }
         log("exiting");
-        new ScoreHigh(type).run(context);
-        new ExitCommunity().run(context);
+        context.runSync(new ScoreHigh(type));
+        context.runSync(new ExitCommunity());
         log("Transitioning");
-        new GyroBalance(alliance.get()).run(context);
+        context.runSync(new GyroBalance(alliance.get()));
     }
 }

--- a/src/main/java/com/team766/robot/gatorade/procedures/RetractWristvatorIdleIntake.java
+++ b/src/main/java/com/team766/robot/gatorade/procedures/RetractWristvatorIdleIntake.java
@@ -5,7 +5,7 @@ import com.team766.framework.Procedure;
 
 public class RetractWristvatorIdleIntake extends Procedure {
     public void run(Context context) {
-        new RetractWristvator().run(context);
-        new IntakeIdle().run(context);
+        context.runSync(new RetractWristvator());
+        context.runSync(new IntakeIdle());
     }
 }

--- a/src/main/java/com/team766/robot/gatorade/procedures/ScoreHigh.java
+++ b/src/main/java/com/team766/robot/gatorade/procedures/ScoreHigh.java
@@ -16,9 +16,9 @@ public class ScoreHigh extends Procedure {
         context.takeOwnership(Robot.intake);
         Robot.intake.setGamePieceType(type);
         context.releaseOwnership(Robot.intake);
-        new ExtendWristvatorToHigh().run(context);
-        new IntakeOut().run(context);
+        context.runSync(new ExtendWristvatorToHigh());
+        context.runSync(new IntakeOut());
         context.waitForSeconds(1);
-        new IntakeStop().run(context);
+        context.runSync(new IntakeStop());
     }
 }

--- a/src/main/java/com/team766/robot/reva/procedures/DriverShootNow.java
+++ b/src/main/java/com/team766/robot/reva/procedures/DriverShootNow.java
@@ -109,7 +109,7 @@ public class DriverShootNow extends VisionPIDProcedure {
         context.waitForConditionOrTimeout(() -> Robot.shoulder.isFinished(), 1);
 
         Robot.lights.signalFinishingShootingProcedure();
-        new DriverShootVelocityAndIntake().run(context);
+        context.runSync(new DriverShootVelocityAndIntake());
     }
 
     private Transform3d getTransform3dOfRobotToTag() throws AprilTagGeneralCheckedException {

--- a/src/main/java/com/team766/robot/reva/procedures/DriverShootVelocityAndIntake.java
+++ b/src/main/java/com/team766/robot/reva/procedures/DriverShootVelocityAndIntake.java
@@ -10,7 +10,7 @@ public class DriverShootVelocityAndIntake extends Procedure {
 
         context.waitForConditionOrTimeout(Robot.shooter::isCloseToExpectedSpeed, 1);
 
-        new IntakeIn().run(context);
+        context.runSync(new IntakeIn());
 
         // Does not stop intake here so driver can stop when button released
     }

--- a/src/main/java/com/team766/robot/reva/procedures/NoRotateShootNow.java
+++ b/src/main/java/com/team766/robot/reva/procedures/NoRotateShootNow.java
@@ -49,7 +49,7 @@ public class NoRotateShootNow extends Procedure {
 
             context.releaseOwnership(Robot.shooter);
             context.releaseOwnership(Robot.shoulder);
-            new ShootVelocityAndIntake(power).run(context);
+            context.runSync(new ShootVelocityAndIntake(power));
 
         } else {
             // context.takeOwnership(Robot.shooter);
@@ -64,7 +64,7 @@ public class NoRotateShootNow extends Procedure {
             // context.releaseOwnership(Robot.shoulder);
             // context.releaseOwnership(Robot.shooter);
 
-            new ShootVelocityAndIntake(3000).run(context);
+            context.runSync(new ShootVelocityAndIntake(3000));
         }
     }
 }

--- a/src/main/java/com/team766/robot/reva/procedures/RotateAndShootNow.java
+++ b/src/main/java/com/team766/robot/reva/procedures/RotateAndShootNow.java
@@ -53,6 +53,6 @@ public class RotateAndShootNow extends Procedure {
         // context.releaseOwnership(Robot.shoulder);
         context.releaseOwnership(Robot.drive);
         context.releaseOwnership(Robot.shooter);
-        new ShootVelocityAndIntake().run(context);
+        context.runSync(new ShootVelocityAndIntake());
     }
 }

--- a/src/main/java/com/team766/robot/reva/procedures/ShootAtSubwoofer.java
+++ b/src/main/java/com/team766/robot/reva/procedures/ShootAtSubwoofer.java
@@ -10,6 +10,6 @@ public class ShootAtSubwoofer extends Procedure {
         context.takeOwnership(Robot.shoulder);
         Robot.shoulder.rotate(ShoulderPosition.SHOOT_LOW);
         context.releaseOwnership(Robot.shoulder);
-        new ShootVelocityAndIntake().run(context);
+        context.runSync(new ShootVelocityAndIntake());
     }
 }

--- a/src/main/java/com/team766/robot/reva/procedures/ShootNow.java
+++ b/src/main/java/com/team766/robot/reva/procedures/ShootNow.java
@@ -113,7 +113,7 @@ public class ShootNow extends VisionPIDProcedure {
 
         context.releaseOwnership(Robot.shooter);
         Robot.lights.signalFinishingShootingProcedure();
-        new ShootVelocityAndIntake(power).run(context);
+        context.runSync(new ShootVelocityAndIntake(power));
         context.releaseOwnership(Robot.drive);
     }
 

--- a/src/main/java/com/team766/robot/reva/procedures/ShootVelocityAndIntake.java
+++ b/src/main/java/com/team766/robot/reva/procedures/ShootVelocityAndIntake.java
@@ -22,12 +22,12 @@ public class ShootVelocityAndIntake extends Procedure {
         Robot.shooter.shoot(speed);
         context.waitForConditionOrTimeout(Robot.shooter::isCloseToExpectedSpeed, 1.5);
 
-        new IntakeIn().run(context);
+        context.runSync(new IntakeIn());
 
         // FIXME: change this value back to 1.5s if doesn't intake for long enough
         context.waitForSeconds(1.2);
 
-        new IntakeStop().run(context);
+        context.runSync(new IntakeStop());
         Robot.lights.signalFinishedShootingProcedure();
 
         // Shooter stopped at the end of auton


### PR DESCRIPTION
## Description

Add runSync to Context for symmetry with startAsync. This allows for more easily switching between them, if necessary, and makes the syntax easier to remember.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Be detailed so that your code reviewer can understand exactly how much and what kinds of testing were done, and which might still be worthwhile to do.

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
