### PR TITLE
use stopMotor() vs PID to stop the shooter

### DIFF
--- a/src/main/java/com/team766/robot/reva/mechanisms/Shooter.java
+++ b/src/main/java/com/team766/robot/reva/mechanisms/Shooter.java
@@ -100,8 +100,8 @@ public class Shooter extends Mechanism {
                 shooterMotorTop.set(ControlMode.Velocity, targetSpeed);
                 shooterMotorBottom.set(ControlMode.Velocity, targetSpeed);
             } else {
-                shooterMotorTop.set(ControlMode.Velocity, 0.0);
-                shooterMotorBottom.set(ControlMode.Velocity, 0.0);
+                shooterMotorTop.stopMotor();
+                shooterMotorBottom.stopMotor();
             }
             speedUpdated = false;
         }


### PR DESCRIPTION
## Description

to allow the shooters to slow down more gradually (vs come to a hard stop), change `Shooter` to call `stopMotor()` on each motor vs set the velocity to 0.

## How Has This Been Tested?

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [x] On-robot bench testing: Tested on RevB as part of bringup.
- [ ] On-robot field testing: [Add your description here]
