### PR TITLE
for consideration - don't move the shoulder at the end of the climb

### DIFF
--- a/src/main/java/com/team766/robot/reva/BoxOpOI.java
+++ b/src/main/java/com/team766/robot/reva/BoxOpOI.java
@@ -103,7 +103,8 @@ public class BoxOpOI extends OIFragment {
                 } else if (gamepad.getPOV() == 180) {
                     shoulder.nudgeDown();
                 }
-            } else if (moveShoulder.isFinishedTriggering()) {
+            } else if (moveShoulder.isFinishedTriggering()
+                    && !enableClimberControls.isFinishedTriggering()) {
                 context.releaseOwnership(shoulder);
             }
         }
@@ -132,10 +133,14 @@ public class BoxOpOI extends OIFragment {
             context.releaseOwnership(climber);
             climber.stop();
 
-            // restore the shoulder
-            context.takeOwnership(shoulder);
-            shoulder.rotate(85);
-            context.releaseOwnership(shoulder);
+            // if a finger slips off of the enable climber controls, it may be disruptive to move
+            // the shoulder
+            // again suddenly, esp if they intend to continue climbing.
+            // it may be better for the boxop to move the shoulder again manually.
+            // // restore the shoulder
+            // context.takeOwnership(shoulder);
+            // shoulder.rotate(85);
+            // context.releaseOwnership(shoulder);
         }
 
         // check to see if we should also disable the climber's soft limits


### PR DESCRIPTION
## Description

something to discuss and consider: Tony was expressing concern that it may be challenging for the BoxOp (Anthony) if a finger slips in the middle of climbing and the shoulder suddenly moves.

also tries to tighten up some logic for releasing the shoulder - some logs were showing shoulder context ownership release without ownership of the context.

## How Has This Been Tested?

just for consideration - needs testing

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
