### PR TITLE
Fix crash if a Context is stopped immediately after creation

### DIFF
--- a/src/main/java/com/team766/framework/Context.java
+++ b/src/main/java/com/team766/framework/Context.java
@@ -335,10 +335,10 @@ public class Context implements Runnable, LaunchedContext {
      * This is the entry point for this Context's worker thread.
      */
     private void threadFunction() {
-        // OS threads run independently of one another, so we need to wait until
-        // the baton is passed to us before we can start running the user's code
-        waitForControl(ControlOwner.SUBROUTINE);
         try {
+            // OS threads run independently of one another, so we need to wait until
+            // the baton is passed to us before we can start running the user's code
+            waitForControl(ControlOwner.SUBROUTINE);
             // Call into the user's code.
             m_func.run(this);
             Logger.get(Category.FRAMEWORK)

--- a/src/test/java/com/team766/framework/ContextTest.java
+++ b/src/test/java/com/team766/framework/ContextTest.java
@@ -1,0 +1,18 @@
+package com.team766.framework;
+
+import com.team766.TestCase;
+import org.junit.jupiter.api.Test;
+
+public class ContextTest extends TestCase {
+    /// Regression test: calling stop() on a Context before it is allowed to
+    /// run the first time should not crash the program.
+    @Test
+    public void testStopOnFirstTick() {
+        var lc = Scheduler.getInstance().startAsync(Procedure.NO_OP);
+        lc.stop();
+
+        step();
+
+        assertTrue(lc.isDone());
+    }
+}


### PR DESCRIPTION
## Description

`Context` waits in the initial `waitForControl` in `threadFunction` from when it first is created until it is first allowed to run. If `stop()` is called on the `Context` during this time, `ContextStoppedException` will be thrown and nothing will catch it. This leads the Thread to crash, which also brings down the JVM, due to our [default exception handler](https://github.com/Team766/2024/blob/2978d8ec1ac80023c6addfaa103c50298f75fe0f/src/main/java/com/team766/logging/Logger.java#L34) (NB: if it didn't bring down the JVM, it would cause a dead-lock, which wouldn't be any better).

`ContextStoppedException` is supposed to be called in a `Context`'s thread when the `Context` is stopped, but it is also supposed to be caught in the `try`-`catch` in `threadFunction`. This PR fixes the issue by moving the initial call to `waitForControl` into the `try`-`catch`.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Be detailed so that your code reviewer can understand exactly how much and what kinds of testing were done, and which might still be worthwhile to do.

- [X] Unit tests: New unit test included in this PR. Test fails in `main` but passes on this branch.
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
