### PR TITLE
Remove the last remnants of JUnit4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,6 @@ dependencies {
     nativeRelease wpi.java.deps.wpilibJniRelease(wpi.platforms.desktop)
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
-    testImplementation 'junit:junit:4.12'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/team766/logging/Logger.java
+++ b/src/main/java/com/team766/logging/Logger.java
@@ -36,6 +36,7 @@ public final class Logger {
     }
 
     private static final int MAX_NUM_RECENT_ENTRIES = 100;
+    private static final String LOG_FILE_PATH_KEY = "logFilePath";
 
     private static EnumMap<Category, Logger> m_loggers =
             new EnumMap<Category, Logger>(Category.class);
@@ -53,8 +54,8 @@ public final class Logger {
         }
         try {
             ConfigFileReader config_file = ConfigFileReader.getInstance();
-            if (config_file != null) {
-                logFilePathBase = config_file.getString("logFilePath").get();
+            if (config_file != null && config_file.containsKey(LOG_FILE_PATH_KEY)) {
+                logFilePathBase = config_file.getString(LOG_FILE_PATH_KEY).get();
                 new File(logFilePathBase).mkdirs();
                 final String timestamp =
                         new SimpleDateFormat("yyyyMMdd'T'HHmmss").format(new Date());
@@ -65,7 +66,9 @@ public final class Logger {
                 get(Category.CONFIGURATION)
                         .logRaw(
                                 Severity.ERROR,
-                                "Config file is not available. Logs will only be in-memory and will be lost when the robot is turned off.");
+                                "Config file does not specify "
+                                        + LOG_FILE_PATH_KEY
+                                        + ". Logs will only be in-memory and will be lost when the robot is turned off.");
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/test/java/com/team766/TestCase.java
+++ b/src/test/java/com/team766/TestCase.java
@@ -1,22 +1,31 @@
 package com.team766;
 
 import com.team766.config.ConfigFileReader;
+import com.team766.config.ConfigFileTestUtils;
 import com.team766.framework.Scheduler;
 import com.team766.hal.RobotProvider;
 import com.team766.hal.mock.TestRobotProvider;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.junit.jupiter.api.BeforeEach;
 
-public abstract class TestCase extends junit.framework.TestCase {
+public abstract class TestCase {
 
-	@Override
-	protected void setUp() throws Exception {
-		ConfigFileReader.instance = new ConfigFileReader(this.getClass().getClassLoader().getResource("testConfig.txt").getPath());
-		RobotProvider.instance = new TestRobotProvider();
+    @BeforeEach
+    public void setUp() {
+        ConfigFileTestUtils.resetStatics();
+        Scheduler.getInstance().reset();
 
-		Scheduler.getInstance().reset();
-	}
+        RobotProvider.instance = new TestRobotProvider();
+    }
 
-	protected void step() {
-		Scheduler.getInstance().run();
-	}
+    protected void loadConfig(String configJson) throws IOException {
+        var configFilePath = Files.createTempFile("testConfig", ".txt");
+        Files.writeString(configFilePath, configJson);
+        ConfigFileReader.instance = new ConfigFileReader(configFilePath.toString());
+    }
 
+    protected void step() {
+        Scheduler.getInstance().run();
+    }
 }

--- a/src/test/java/com/team766/config/ConfigFileReaderTest.java
+++ b/src/test/java/com/team766/config/ConfigFileReaderTest.java
@@ -2,26 +2,15 @@ package com.team766.config;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.File;
-import java.io.FileWriter;
+import com.team766.TestCase;
 import java.io.IOException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ConfigFileReaderTest {
-    @BeforeEach
-    public void setup() {
-        AbstractConfigValue.resetStatics();
-    }
-
+public class ConfigFileReaderTest extends TestCase {
     @Test
     public void getJsonStringFromEmptyConfigFile() throws IOException {
-        File testConfigFile = File.createTempFile("config_file_test", ".json");
-        try (FileWriter fos = new FileWriter(testConfigFile)) {
-            fos.append("{}");
-        }
+        loadConfig("{}");
 
-        ConfigFileReader.instance = new ConfigFileReader(testConfigFile.getPath());
         ConfigFileReader.getInstance().getString("test.sub.key");
         assertEquals(
                 "{\"test\": {\"sub\": {\"key\": null}}}",
@@ -30,12 +19,8 @@ public class ConfigFileReaderTest {
 
     @Test
     public void getJsonStringFromPartialConfigFile() throws IOException {
-        File testConfigFile = File.createTempFile("config_file_test", ".json");
-        try (FileWriter fos = new FileWriter(testConfigFile)) {
-            fos.append("{\"test\": {\"sub\": {\"key\": \"pi\", \"value\": 3.14159}}}");
-        }
+        loadConfig("{\"test\": {\"sub\": {\"key\": \"pi\", \"value\": 3.14159}}}");
 
-        ConfigFileReader.instance = new ConfigFileReader(testConfigFile.getPath());
         assertEquals("pi", ConfigFileReader.getInstance().getString("test.sub.key").get());
         assertEquals(
                 3.14159,

--- a/src/test/java/com/team766/config/ConfigFileTestUtils.java
+++ b/src/test/java/com/team766/config/ConfigFileTestUtils.java
@@ -1,0 +1,7 @@
+package com.team766.config;
+
+public class ConfigFileTestUtils {
+    public static void resetStatics() {
+        AbstractConfigValue.resetStatics();
+    }
+}

--- a/src/test/java/com/team766/framework/ContextTest.java
+++ b/src/test/java/com/team766/framework/ContextTest.java
@@ -1,5 +1,7 @@
 package com.team766.framework;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.team766.TestCase;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/team766/framework/YieldWithValueTest.java
+++ b/src/test/java/com/team766/framework/YieldWithValueTest.java
@@ -1,5 +1,7 @@
 package com.team766.framework;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.team766.TestCase;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
## Description

JUnit4 support has been dropped by WPILib and its gradle files, so make sure we aren't using it anymore.

## How Has This Been Tested?

- [X] Unit tests: Ran existing unit tests
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
