### PR TITLE
Remove ratchetFrom from spotless config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,6 @@ task(checkAkitInstall, dependsOn: "classes", type: JavaExec) {
 compileJava.finalizedBy checkAkitInstall
 
 spotless {
-    ratchetFrom 'origin/main' // only check files that have changed relative to main
     java {
         target fileTree('.') {
             include '**/*.java'


### PR DESCRIPTION
## Description

All of the format violations in `main` were resolved in https://github.com/Team766/2024/pull/124 so we don't need this config anymore. This config also doesn't work with `git worktree`, which has been annoying me :)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Be detailed so that your code reviewer can understand exactly how much and what kinds of testing were done, and which might still be worthwhile to do.

- [X] Unit tests: CI tests
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
