### PR TITLE
Run simulation in the CodeSpaces container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java
+{
+	"name": "Java",
+	"image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
+
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "17"
+		},
+		"ghcr.io/devcontainers/features/python:1": {
+			"installTools": true,
+			"version": "3.12"
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8000],
+
+	"portsAttributes": {
+		"5800": {
+			"label": "Robot code HTML dashboard",
+			"onAutoForward": "silent"
+		},
+		"7778": {
+			// This port is only used locally; the HTTP server exposes this to the client via a proxy.
+			"label": "Simulation WebSockets",
+			"onAutoForward": "silent"
+		},
+		"8000": {
+			// This port is only used locally; the HTTP server exposes this to the client via a proxy.
+			"label": "Simulation HTTP",
+			"onAutoForward": "openBrowser"
+		}
+	}
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ logs/
 
 # Folder that has CTRE Phoenix Sim device config storage
 ctre_sim/
+
+# Don't commit the cache of downloaded sim files
+/buildSim/

--- a/simConfig.txt
+++ b/simConfig.txt
@@ -1,5 +1,4 @@
 {
-	"logFilePath": "sim_robot_logs",
 	"drive": {
 		"leftMotor": {
 			"deviceId": 6,

--- a/src/main/java/com/team766/web/WebServer.java
+++ b/src/main/java/com/team766/web/WebServer.java
@@ -94,6 +94,7 @@ public class WebServer {
                                 throw ex;
                             }
                             response += "</body></html>";
+                            exchange.getResponseHeaders().set("Content-Type", "text/html");
                             exchange.sendResponseHeaders(200, response.getBytes().length);
                             try (OutputStream os = exchange.getResponseBody()) {
                                 os.write(response.getBytes());


### PR DESCRIPTION
## Description

Run the 3D simulator in each user's Codespaces container instead of having persistent instances on Digital Ocean. This means that each user automatically gets their own simulation instance, and we save $80-$250 per month on DO fees.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Be detailed so that your code reviewer can understand exactly how much and what kinds of testing were done, and which might still be worthwhile to do.

- [ ] Unit tests: [Add your description here]
- [X] Simulator testing: See https://github.com/Team766/MaroonFramework/pull/35
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
