### PR TITLE
simple change to add a combined spotless apply and build task to ctrl/cmd+shift+b

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -55,6 +55,25 @@
                 "kind": "build",
                 "isDefault": true
             }
+        },
+        {
+            "label": "Spotless Apply and Build",
+            "type": "shell",
+            "command": "./gradlew spotlessApply build",
+            "problemMatcher": [],
+            "showOutput": "always",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "dedicated",
+                "showReuseMessage": false,
+                "clear": true
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         }
     ]
 }


### PR DESCRIPTION
## Description

Adds a new option to the build tasks (ctrl/cmd+shift+b), to check and apply lint changes (spotless) and then builds the code.  (As an alternative, we could also create a new gradle task to handle this as a single task.)

## How Has This Been Tested?

Tested by doing builds