### PR TITLE
Make Request type parameterized by Status type

### DIFF
--- a/src/main/java/com/team766/framework3/Conditions.java
+++ b/src/main/java/com/team766/framework3/Conditions.java
@@ -66,7 +66,7 @@ public class Conditions {
 
     public static class AwaitRequest<S extends Status> extends StatusCheck<S> {
 
-        public AwaitRequest(Class<S> clazz, Request request) {
+        public AwaitRequest(Class<S> clazz, Request<S> request) {
             super(clazz, request::isDone);
         }
     }

--- a/src/main/java/com/team766/framework3/Mechanism.java
+++ b/src/main/java/com/team766/framework3/Mechanism.java
@@ -8,7 +8,7 @@ import com.team766.logging.LoggerExceptionUtils;
 import com.team766.logging.Severity;
 
 // TODO: add javadoc
-public abstract class Mechanism<R extends Request> extends LoggingBase {
+public abstract class Mechanism<R extends Request<?>> extends LoggingBase {
     private ContextImpl m_owningContext = null;
     private Thread m_runningPeriodic = null;
 

--- a/src/main/java/com/team766/framework3/Request.java
+++ b/src/main/java/com/team766/framework3/Request.java
@@ -9,13 +9,13 @@ package com.team766.framework3;
  *
  * Each Mechanism will have its own implementation of the {@link Request} marker interface.
  */
-public interface Request {
+public interface Request<S extends Status> {
 
     /**
      * Checks whether or not this request has been fulfilled, via the supplied {@link Status}.  This
      * {@link Status} should be the latest one retrieved via {@link StatusBus#getStatus(Class)}.
      */
-    boolean isDone(Status status);
+    boolean isDone(S status);
 
     // TODO: do we need any way of checking if the request has been bumped/canceled?
 }


### PR DESCRIPTION
## Description

Strengthen types so that implementations of `isDone` don't have to cast to the specific Status subtype.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Be detailed so that your code reviewer can understand exactly how much and what kinds of testing were done, and which might still be worthwhile to do.

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
