### PR TITLE
StatusBus keyed directly by status class

### DIFF
--- a/src/main/java/com/team766/framework3/StatusBus.java
+++ b/src/main/java/com/team766/framework3/StatusBus.java
@@ -14,11 +14,7 @@ import java.util.Map;
 public class StatusBus extends LoggingBase {
 
     private static StatusBus s_instance = new StatusBus();
-    private final Map<String, Status> statuses = new LinkedHashMap<String, Status>();
-
-    private static String computeKey(Class<? extends Status> statusClass) {
-        return statusClass.toString();
-    }
+    private final Map<Class<? extends Status>, Status> statuses = new LinkedHashMap<>();
 
     /**
      * Get the Singleton instance of the {@link StatusBus}.
@@ -39,8 +35,7 @@ public class StatusBus extends LoggingBase {
      * This method also logs the Status to diagnostic logs.
      */
     public void publish(Status status) {
-        String key = computeKey(status.getClass());
-        statuses.put(key, status);
+        statuses.put(status.getClass(), status);
         // TODO: also publish to data logs
         log("StatusBus received Status (" + status.getClass().getName() + "): " + status);
     }
@@ -56,8 +51,7 @@ public class StatusBus extends LoggingBase {
      */
     @SuppressWarnings("unchecked")
     public <S extends Status> S getStatus(Class<S> statusClass) {
-        String key = computeKey(statusClass);
-        return (S) statuses.get(key);
+        return (S) statuses.get(statusClass);
     }
 
     @Override


### PR DESCRIPTION
## Description

As long as we don't do hot reloading or crazy things with ClassLoaders, there is exactly one `Class` object for each class. As such, it is safe to use `Class<?>` as `HashMap` keys because it will use the default `Object` implementations of `equals` and `hashCode` which are based on object identity. https://stackoverflow.com/a/54076411

Small performance gain over requiring hash and equality computations on strings.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Be detailed so that your code reviewer can understand exactly how much and what kinds of testing were done, and which might still be worthwhile to do.

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
