### PR TITLE
Set VSCode to indent with spaces by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,7 @@
   "java.test.defaultConfig": "WPIlibUnitTests",
   
   "editor.formatOnSave": false,
-  "editor.insertSpaces": false,
+  "editor.insertSpaces": true,
   "editor.tabSize": 4,
   "diffEditor.ignoreTrimWhitespace": false,
   "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml",


### PR DESCRIPTION
## Description

Our spotless config requires 4-space indents, so it's most helpful to have VSCode use the same convention.