### PR TITLE
Modify CodeSpace devcontainer.json to run sshd by default.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,9 @@
 		"ghcr.io/devcontainers/features/python:1": {
 			"installTools": true,
 			"version": "3.12"
+		},
+		"ghcr.io/devcontainers/features/sshd:1": {
+			"version": "latest"
 		}
 	},
 


### PR DESCRIPTION
## Description

Modify devcontainer.json to run sshd by default.  This allows devs to ssh into their codespaces via `gh codespace ssh`.

## How Has This Been Tested?

`gh codespace ssh`