### PR TITLE
Pre-initialize autonomous Procedure

### DIFF
--- a/src/main/java/com/team766/framework3/AutonomousModeStateMachine.java
+++ b/src/main/java/com/team766/framework3/AutonomousModeStateMachine.java
@@ -1,0 +1,92 @@
+package com.team766.framework3;
+
+import com.team766.logging.Category;
+import com.team766.logging.Logger;
+import com.team766.logging.Severity;
+import edu.wpi.first.wpilibj2.command.Command;
+import java.util.function.Supplier;
+
+public class AutonomousModeStateMachine {
+    private enum AutonomousState {
+        /**
+         * m_autonomous has not been started yet.
+         * It can be scheduled the next time autonomousInit is called.
+         */
+        NEW,
+        /**
+         * m_autonomous is currently running.
+         */
+        SCHEDULED,
+        /**
+         * m_autonomous has finished, has been canceled, or is null.
+         * A new instance of the autonomous Command needs to be created before
+         * autonomous mode can be enabled.
+         */
+        INVALID,
+    }
+
+    private final Supplier<AutonomousMode> selector;
+    private AutonomousMode m_autonMode = null;
+    private Command m_autonomous = null;
+    private AutonomousState m_autonState = AutonomousState.INVALID;
+
+    public AutonomousModeStateMachine(Supplier<AutonomousMode> selector) {
+        this.selector = selector;
+    }
+
+    public void stopAutonomousMode(final String reason) {
+        if (m_autonState == AutonomousState.SCHEDULED) {
+            m_autonomous.cancel();
+            m_autonState = AutonomousState.INVALID;
+            Logger.get(Category.AUTONOMOUS)
+                    .logRaw(Severity.INFO, "Resetting autonomus procedure from " + reason);
+        }
+    }
+
+    private void refreshAutonomousMode() {
+        final AutonomousMode autonomousMode = selector.get();
+        if (m_autonMode != autonomousMode) {
+            stopAutonomousMode("selection of new autonomous mode " + autonomousMode);
+            m_autonState = AutonomousState.INVALID;
+        }
+        if (m_autonState == AutonomousState.INVALID && autonomousMode != null) {
+            m_autonomous = autonomousMode.instantiate();
+            m_autonMode = autonomousMode;
+            m_autonState = AutonomousState.NEW;
+            Logger.get(Category.AUTONOMOUS)
+                    .logRaw(
+                            Severity.INFO,
+                            "Initialized new autonomus procedure " + m_autonomous.getName());
+        }
+    }
+
+    public void startAutonomousMode() {
+        refreshAutonomousMode();
+        switch (m_autonState) {
+            case INVALID -> {
+                Logger.get(Category.AUTONOMOUS)
+                        .logRaw(Severity.WARNING, "No autonomous mode selected");
+            }
+            case SCHEDULED -> {
+                Logger.get(Category.AUTONOMOUS)
+                        .logRaw(
+                                Severity.INFO,
+                                "Continuing previous autonomus procedure "
+                                        + m_autonomous.getName());
+            }
+            case NEW -> {
+                m_autonomous.schedule();
+                m_autonState = AutonomousState.SCHEDULED;
+                Logger.get(Category.AUTONOMOUS)
+                        .logRaw(
+                                Severity.INFO,
+                                "Starting new autonomus procedure " + m_autonomous.getName());
+            }
+        }
+    }
+
+    public void reinitializeAutonomousMode(final String reason) {
+        stopAutonomousMode(reason);
+        refreshAutonomousMode();
+    }
+}

--- a/src/test/java/com/team766/TestCase3.java
+++ b/src/test/java/com/team766/TestCase3.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 public abstract class TestCase3 {
 
     @BeforeEach
-    public void setUp() {
+    public final void setUpFramework() {
         assert HAL.initialize(500, 0);
 
         ConfigFileTestUtils.resetStatics();

--- a/src/test/java/com/team766/framework3/AutonomousModeStateMachineTest.java
+++ b/src/test/java/com/team766/framework3/AutonomousModeStateMachineTest.java
@@ -1,0 +1,286 @@
+package com.team766.framework3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.team766.TestCase3;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.RunCommand;
+import java.util.ArrayList;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AutonomousModeStateMachineTest extends TestCase3 {
+    private int autonomousModeInstanceCounter;
+    private int procedureAge;
+    private AutonomousMode selectedAutonomousMode;
+    private ArrayList<Command> commands;
+    private AutonomousModeStateMachine sm;
+
+    @BeforeEach
+    public void setUp() {
+        autonomousModeInstanceCounter = 0;
+        commands = new ArrayList<>();
+        Supplier<AutonomousMode> supplier = () -> selectedAutonomousMode;
+        sm = new AutonomousModeStateMachine(supplier);
+    }
+
+    private void selectNewAutonomousMode() {
+        final int thisInstanceCount = ++autonomousModeInstanceCounter;
+        selectedAutonomousMode =
+                new AutonomousMode(
+                        "Auton" + thisInstanceCount,
+                        () -> {
+                            assertEquals(thisInstanceCount, autonomousModeInstanceCounter);
+                            procedureAge = 0;
+                            var procedure =
+                                    new RunCommand(() -> ++procedureAge).ignoringDisable(true);
+                            commands.add(procedure);
+                            return procedure;
+                        });
+    }
+
+    /// Represents the code running when the user hasn't selected an autonomous mode via the web UI.
+    @Test
+    public void testOperationsWithNullAutonomousMode() {
+        selectedAutonomousMode = null;
+
+        sm.stopAutonomousMode("stopping");
+        sm.reinitializeAutonomousMode("reinitializing");
+        sm.startAutonomousMode();
+        sm.stopAutonomousMode("stopping");
+    }
+
+    /// This represents the case where the robot code enters teleop without first running
+    /// autonomous.
+    /// Doesn't result in any action being taken, but we want to make sure it doesn't trigger a
+    /// NullPointerException or any other bad side effect.
+    @Test
+    public void testStopWithoutStart() {
+        selectNewAutonomousMode();
+
+        sm.stopAutonomousMode("stopping");
+
+        assertEquals(0, commands.size());
+    }
+
+    /// This represents the case where the RoboRIO reboots during autonomous mode, so the
+    /// robot code directly enters autonomous without being disabled first.
+    /// The robot should initialize and run an instance of the autonomous Command.
+    @Test
+    public void testStartWithoutInitialize() {
+        selectNewAutonomousMode();
+
+        sm.startAutonomousMode();
+
+        assertEquals(1, commands.size());
+        assertTrue(commands.get(0).isScheduled());
+    }
+
+    /// This represents the usual case where a robot sits in disabled mode for a while
+    /// before autonomous is enabled.
+    /// The robot should initialize the autonomous Command while in disabled, and then use
+    /// that Command when autonomous starts.
+    @Test
+    public void testStartAfterInitialize() {
+        selectNewAutonomousMode();
+
+        sm.reinitializeAutonomousMode("initializing");
+        sm.reinitializeAutonomousMode("initializing again");
+
+        assertEquals(1, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+
+        sm.startAutonomousMode();
+
+        assertEquals(1, commands.size());
+        assertTrue(commands.get(0).isScheduled());
+    }
+
+    /// Calling startAutonomousMode twice is representative of what would happen if the robot
+    /// becomes momentarily disabled during autonomous, for example from a transient wifi issue.
+    /// No new Command should be created in the second call - the one created during the first
+    /// call to startAutonomousMode should be continued.
+    @Test
+    public void testResume() {
+        selectNewAutonomousMode();
+
+        sm.startAutonomousMode();
+
+        assertEquals(1, commands.size());
+        assertTrue(commands.get(0).isScheduled());
+
+        sm.startAutonomousMode();
+
+        assertEquals(1, commands.size());
+        assertTrue(commands.get(0).isScheduled());
+    }
+
+    /// Test the usual case where the robot runs autonomous and then enters teleop.
+    @Test
+    public void testStop() {
+        selectNewAutonomousMode();
+
+        sm.startAutonomousMode();
+
+        assertEquals(1, commands.size());
+        assertTrue(commands.get(0).isScheduled());
+
+        sm.stopAutonomousMode("stopping");
+
+        assertEquals(1, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+
+        sm.stopAutonomousMode("stopping again");
+
+        assertEquals(1, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+    }
+
+    /// Autonomous -> Teleop -> Autonomous. This could happen frequently during testing
+    /// in the shop, or after a field fault in competition. Should create a second instance
+    /// of the autononomus Command for the second run of autonomous.
+    @Test
+    public void testRunTwice() {
+        selectNewAutonomousMode();
+
+        sm.startAutonomousMode();
+
+        assertEquals(1, commands.size());
+        assertTrue(commands.get(0).isScheduled());
+
+        sm.stopAutonomousMode("stopping");
+
+        assertEquals(1, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+
+        sm.startAutonomousMode();
+
+        assertEquals(2, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+        assertTrue(commands.get(1).isScheduled());
+    }
+
+    /// Autonomous -> Teleop -> Disabled -> Autonomous
+    @Test
+    public void testRunTwiceWithReinitialize() {
+        selectNewAutonomousMode();
+
+        sm.startAutonomousMode();
+
+        assertEquals(1, commands.size());
+        assertTrue(commands.get(0).isScheduled());
+
+        sm.stopAutonomousMode("stopping");
+
+        assertEquals(1, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+
+        sm.reinitializeAutonomousMode("reinitializing");
+
+        assertEquals(2, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+        assertFalse(commands.get(1).isScheduled());
+
+        sm.startAutonomousMode();
+
+        assertEquals(2, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+        assertTrue(commands.get(1).isScheduled());
+    }
+
+    /// If the user selects a different autonomous mode while the robot is in disabled mode,
+    /// an instance of the new mode's Command should be instantiated and then used when the robot
+    /// enters autnonomous.
+    @Test
+    public void testNewSelectionWhenDisabled() {
+        selectNewAutonomousMode();
+
+        sm.reinitializeAutonomousMode("initializing");
+
+        assertEquals(1, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+
+        selectNewAutonomousMode();
+
+        sm.reinitializeAutonomousMode("reinitializing");
+
+        assertEquals(2, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+        assertFalse(commands.get(1).isScheduled());
+
+        sm.startAutonomousMode();
+
+        assertEquals(2, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+        assertTrue(commands.get(1).isScheduled());
+    }
+
+    /// If the user selects a different autonomous mode between two autonomous runs,
+    /// an instance of the new mode's Command should be instantiated and then used when the robot
+    /// enters autnonomous the second time.
+    @Test
+    public void testRunTwiceWithNewSelection() {
+        selectNewAutonomousMode();
+
+        sm.startAutonomousMode();
+
+        assertEquals(1, commands.size());
+        assertTrue(commands.get(0).isScheduled());
+
+        sm.stopAutonomousMode("stopping");
+
+        selectNewAutonomousMode();
+
+        sm.startAutonomousMode();
+
+        assertEquals(2, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+        assertTrue(commands.get(1).isScheduled());
+    }
+
+    /// If the user removes their selection of an autonomous mode after it has been initialized,
+    /// the robot should not run any Command when the robot enters autonomous.
+    @Test
+    public void testDeselectionWhenDisabled() {
+        selectNewAutonomousMode();
+
+        sm.reinitializeAutonomousMode("initializing");
+
+        assertEquals(1, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+
+        selectedAutonomousMode = null;
+
+        sm.reinitializeAutonomousMode("reinitializing");
+
+        assertEquals(1, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+
+        sm.startAutonomousMode();
+
+        assertEquals(1, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+    }
+
+    /// If the user removes their selection of an autonomous mode between two autonomous runs,
+    /// the robot should not run any Command when the robot enters autonomous  the second time.
+    @Test
+    public void testRunTwiceWithDeselection() {
+        selectNewAutonomousMode();
+
+        sm.startAutonomousMode();
+
+        assertEquals(1, commands.size());
+        assertTrue(commands.get(0).isScheduled());
+
+        sm.stopAutonomousMode("stopping");
+
+        selectedAutonomousMode = null;
+
+        sm.startAutonomousMode();
+
+        assertEquals(1, commands.size());
+        assertFalse(commands.get(0).isScheduled());
+    }
+}


### PR DESCRIPTION
## Description

Instantiate the autonomous mode Procedure while the robot is still in disabled mode, rather than waiting for autonomous mode to be enabled. This means that expensive initialization (such as deserializing path files) doesn't delay the start of the autonomous routine.

## How Has This Been Tested?

- [X] Unit tests: Unit tests included
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
