### PR TITLE
Add isConnected method to encoders

### DIFF
--- a/src/main/java/com/team766/hal/EncoderReader.java
+++ b/src/main/java/com/team766/hal/EncoderReader.java
@@ -13,6 +13,11 @@ public interface EncoderReader extends ControlInputReader {
     void reset();
 
     /**
+     * Return true iff the encoder's readings are up-to-date.
+     */
+    boolean isConnected();
+
+    /**
      * Get the distance the robot has driven since the last reset.
      *
      * @return The distance driven since the last reset as scaled by the value from

--- a/src/main/java/com/team766/hal/mock/MockEncoder.java
+++ b/src/main/java/com/team766/hal/mock/MockEncoder.java
@@ -7,12 +7,18 @@ public class MockEncoder implements EncoderReader {
     private double distance = 0;
     private double rate = 0;
     private double distancePerPulse = 1;
+    private boolean isConnected = false;
 
     public MockEncoder() {}
 
     @Override
     public void reset() {
         distance = 0;
+    }
+
+    @Override
+    public boolean isConnected() {
+        return isConnected;
     }
 
     @Override
@@ -27,10 +33,16 @@ public class MockEncoder implements EncoderReader {
 
     public void setDistance(final double distance_) {
         this.distance = distance_;
+        this.isConnected = true;
     }
 
     public void setRate(final double rate_) {
         this.rate = rate_;
+        this.isConnected = true;
+    }
+
+    public void disconnect() {
+        isConnected = false;
     }
 
     @Override

--- a/src/main/java/com/team766/hal/simulator/Encoder.java
+++ b/src/main/java/com/team766/hal/simulator/Encoder.java
@@ -18,6 +18,11 @@ public class Encoder implements EncoderReader {
     }
 
     @Override
+    public boolean isConnected() {
+        return true;
+    }
+
+    @Override
     public double getDistance() {
         int distance = (int) ProgramInterface.encoderChannels[channel].distance;
         return distance * distancePerPulse;

--- a/src/main/java/com/team766/hal/wpilib/CANcoderEncoder.java
+++ b/src/main/java/com/team766/hal/wpilib/CANcoderEncoder.java
@@ -21,6 +21,11 @@ public class CANcoderEncoder implements EncoderReader {
     }
 
     @Override
+    public boolean isConnected() {
+        return cancoder.getPosition().getStatus().isOK();
+    }
+
+    @Override
     public double getDistance() {
         StatusSignal<Double> position = cancoder.getPosition();
         if (!position.getStatus().isOK()) {

--- a/src/main/java/com/team766/hal/wpilib/Encoder.java
+++ b/src/main/java/com/team766/hal/wpilib/Encoder.java
@@ -6,4 +6,9 @@ public class Encoder extends edu.wpi.first.wpilibj.Encoder implements EncoderRea
     public Encoder(final int channelA, final int channelB) {
         super(channelA, channelB);
     }
+
+    @Override
+    public boolean isConnected() {
+        return true;
+    }
 }


### PR DESCRIPTION
## Description

`isConnected()` should return true iff the software is receiving up-to-date and correct information from the encoder. This is primarily useful with the Rev absolute encoders, but also is applicable to CANcoders.

example use: https://github.com/Team766/2024/blob/1060e1cc685aeba045737cf196f1ba9626844548/src/main/java/com/team766/robot/burro_arm/mechanisms/Arm.java#L51-L62

## How Has This Been Tested?

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [X] On-robot bench testing: Tested on m-ayhem demo bot
- [ ] On-robot field testing: [Add your description here]
