### PR TITLE
Mechanism initial and idle requests

### DIFF
--- a/src/main/java/com/team766/framework3/Mechanism.java
+++ b/src/main/java/com/team766/framework3/Mechanism.java
@@ -4,8 +4,10 @@ import com.team766.logging.Category;
 import com.team766.logging.Logger;
 import com.team766.logging.LoggerExceptionUtils;
 import com.team766.logging.Severity;
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import java.util.Objects;
 
 public abstract class Mechanism<R extends Request<?>> extends SubsystemBase implements LoggingBase {
     private Thread m_runningPeriodic = null;
@@ -13,16 +15,78 @@ public abstract class Mechanism<R extends Request<?>> extends SubsystemBase impl
     private R request = null;
     private boolean isRequestNew = false;
 
+    /**
+     * This Command runs when no other Command (i.e. Procedure) is reserving this Mechanism.
+     * If this Mechanism defines getIdleRequest, this Command serves to apply that request.
+     */
+    private final class IdleCommand extends Command {
+        public IdleCommand() {
+            addRequirements(Mechanism.this);
+        }
+
+        @Override
+        public void initialize() {
+            try {
+                final var r = getIdleRequest();
+                if (r != null) {
+                    SchedulerMonitor.currentCommand = this;
+                    setRequest(r);
+                }
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                LoggerExceptionUtils.logException(ex);
+            } finally {
+                SchedulerMonitor.currentCommand = null;
+            }
+        }
+
+        @Override
+        public boolean isFinished() {
+            return false;
+        }
+    }
+
+    public Mechanism() {
+        setDefaultCommand(new IdleCommand());
+    }
+
     @Override
     public Category getLoggerCategory() {
         return Category.MECHANISMS;
     }
 
     public final void setRequest(R request) {
+        Objects.requireNonNull(request);
         checkContextReservation();
         this.request = request;
         isRequestNew = true;
         log(this.getClass().getName() + " processing request: " + request);
+    }
+
+    /**
+     * The request returned by this method will be set as the request for this Mechanism when the
+     * Mechanism is first created.
+     *
+     * If this Mechanism defines getIdleRequest(), then this Initial request will only be passed to
+     * the first call to run() (after that, the Idle request may take over). Otherwise, this Initial
+     * request will be passed to run() until something calls setRequest() on this Mechanism.
+     *
+     * This method will only be called once, immediately before the first call to run(). Because it
+     * is called before run(), it cannot call getMechanismStatus() or otherwise depend on the Status
+     * published by this Mechanism.
+     */
+    protected abstract R getInitialRequest();
+
+    /**
+     * The request returned by this method will be set as the request for this Mechanism when no
+     * Procedures are reserving this Mechanism. This happens when a Procedure which reserved this
+     * Mechanism completes. It can also happen when a Procedure that reserves this Mechanism is
+     * preempted by another Procedure, but the new Procedure does not reserve this Mechanism.
+     * getIdleRequest is especially in the latter case, because it can help to "clean up" after the
+     * cancelled Procedure, returning this Mechanism back to some safe state.
+     */
+    protected R getIdleRequest() {
+        return null;
     }
 
     protected void checkContextReservation() {
@@ -50,6 +114,9 @@ public abstract class Mechanism<R extends Request<?>> extends SubsystemBase impl
 
         try {
             m_runningPeriodic = Thread.currentThread();
+            if (request == null) {
+                setRequest(getInitialRequest());
+            }
             boolean wasRequestNew = isRequestNew;
             isRequestNew = false;
             run(request, wasRequestNew);

--- a/src/main/java/com/team766/hal/GenericRobotMain3.java
+++ b/src/main/java/com/team766/hal/GenericRobotMain3.java
@@ -162,11 +162,11 @@ public final class GenericRobotMain3 implements GenericRobotMainBase {
     public void teleopPeriodic() {
         if (faultInRobotInit || faultInTeleopInit) return;
 
+        CommandScheduler.getInstance().run();
         if (m_oi != null && RobotProvider.instance.hasNewDriverStationData()) {
             RobotProvider.instance.refreshDriverStationData();
             m_oi.run();
         }
-        CommandScheduler.getInstance().run();
         if (m_lights != null && m_lightUpdateLimiter.next()) {
             m_lights.run();
         }

--- a/src/test/java/com/team766/TestCase3.java
+++ b/src/test/java/com/team766/TestCase3.java
@@ -7,11 +7,15 @@ import com.team766.framework3.TestLoggerExtension;
 import com.team766.hal.RobotProvider;
 import com.team766.hal.mock.TestRobotProvider;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import java.io.IOException;
 import java.nio.file.Files;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.littletonrobotics.conduit.ConduitApi;
+import org.littletonrobotics.junction.inputs.LoggedDriverStation;
+import org.littletonrobotics.junction.inputs.LoggedSystemStats;
 
 @ExtendWith(TestLoggerExtension.class)
 public abstract class TestCase3 {
@@ -20,10 +24,34 @@ public abstract class TestCase3 {
     public void setUp() {
         assert HAL.initialize(500, 0);
 
+        setRobotEnabled(true);
+
         ConfigFileTestUtils.resetStatics();
         SchedulerUtils.reset();
 
         RobotProvider.instance = new TestRobotProvider();
+    }
+
+    protected void setRobotEnabled(boolean enabled) {
+        DriverStationSim.setDsAttached(true);
+        DriverStationSim.setEnabled(enabled);
+        updateDriverStationData();
+    }
+
+    protected void setRobotAutonomous(boolean autonomous) {
+        DriverStationSim.setAutonomous(autonomous);
+        updateDriverStationData();
+    }
+
+    protected void updateDriverStationData() {
+        // Flush data that was set using DriverStationSim
+        DriverStationSim.notifyNewData();
+        // AdvantageKit inserts itself into DriverStation, so we also need to flush AdvantageKit
+        // data in order for DriverStation to get the updated data.
+        // https://github.com/Mechanical-Advantage/AdvantageKit/blob/e236e4bf57188addc3befd2d827660b470d9af89/docs/COMMON-ISSUES.md#unit-testing
+        ConduitApi.getInstance().captureData();
+        LoggedDriverStation.periodic();
+        LoggedSystemStats.periodic();
     }
 
     protected void loadConfig(String configJson) throws IOException {
@@ -33,6 +61,7 @@ public abstract class TestCase3 {
     }
 
     protected void step() {
+        updateDriverStationData();
         CommandScheduler.getInstance().run();
     }
 }

--- a/src/test/java/com/team766/framework3/FakeMechanism.java
+++ b/src/test/java/com/team766/framework3/FakeMechanism.java
@@ -10,15 +10,18 @@ class FakeMechanism extends Mechanism<FakeMechanism.FakeRequest> {
         }
     }
 
-    private FakeRequest currentRequest;
+    FakeRequest currentRequest;
+    Boolean wasRequestNew = null;
 
-    public FakeRequest currentRequest() {
-        return currentRequest;
+    @Override
+    protected FakeRequest getInitialRequest() {
+        return new FakeRequest(-1);
     }
 
     @Override
     protected void run(FakeRequest request, boolean isRequestNew) {
-        this.currentRequest = request;
+        currentRequest = request;
+        wasRequestNew = isRequestNew;
     }
 }
 


### PR DESCRIPTION
## Description

Add customization points for a Mechanism to specify an Initial request and Idle request.

The Initial request will be set as the request when the Mechanism is first created. If the Mechanism also defines an Idle request, then the Initial request will only be passed to the first call to `run()` (after that, the Idle request may take over). Otherwise, the Initial request will be passed to `run()` until something calls `setRequest()` on the Mechanism.

The Idle request will be set as the request for the Mechanism when no Procedures are reserving the Mechanism.

Each Mechanism is required to have an Initial request; specifying an Idle request is optional. If no Idle request is specified, the Mechanism will continue to run its last request after the reservation ends.

## How Has This Been Tested?

- [X] Unit tests: Unit tests for new functionality are included
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
