### PR TITLE
Reset rules when higher priority rules trigger

### DIFF
--- a/src/main/java/com/team766/framework3/Rule.java
+++ b/src/main/java/com/team766/framework3/Rule.java
@@ -157,6 +157,10 @@ public class Rule {
         return currentTriggerType;
     }
 
+    /* package */ void reset() {
+        currentTriggerType = TriggerType.NONE;
+    }
+
     /* package */ void evaluate() {
         if (predicate.getAsBoolean()) {
             currentTriggerType =

--- a/src/main/java/com/team766/framework3/RuleEngine.java
+++ b/src/main/java/com/team766/framework3/RuleEngine.java
@@ -106,6 +106,7 @@ public class RuleEngine implements LoggingBase {
                                             + "; mechanism "
                                             + mechanism.getName()
                                             + " already reserved by higher priority rule.");
+                            rule.reset();
                             continue ruleLoop;
                         }
                         // see if a previously triggered rule is still using the mechanism
@@ -123,11 +124,24 @@ public class RuleEngine implements LoggingBase {
                                     log(
                                             Severity.INFO,
                                             "RULE CONFLICT!  Ignoring rule: "
-                                                    + rule
+                                                    + rule.getName()
                                                     + "; mechanism "
                                                     + mechanism.getName()
                                                     + " already being used in CommandScheduler by higher priority rule.");
+                                    rule.reset();
                                     continue ruleLoop;
+                                } else if (rule != existingRule) {
+                                    // new rule takes priority
+                                    // reset existing rule
+                                    log(
+                                            Severity.INFO,
+                                            "Pre-empting rule: "
+                                                    + existingRule.getName()
+                                                    + "; mechanism "
+                                                    + mechanism.getName()
+                                                    + " will now be reserved by higher priority rule "
+                                                    + rule.getName());
+                                    existingRule.reset();
                                 }
                             }
                         }

--- a/src/test/java/com/team766/framework3/RuleEngineTest.java
+++ b/src/test/java/com/team766/framework3/RuleEngineTest.java
@@ -32,10 +32,8 @@ public class RuleEngineTest extends TestCase3 {
 
         @Override
         public boolean getAsBoolean() {
-            System.err.println("CYCLE: " + currentCycle);
             boolean value = currentCycle >= start && currentCycle < end;
             ++currentCycle;
-            System.err.println("VALUE: " + value);
             return value;
         }
     }

--- a/src/test/java/com/team766/framework3/RuleEngineTest.java
+++ b/src/test/java/com/team766/framework3/RuleEngineTest.java
@@ -32,10 +32,9 @@ public class RuleEngineTest extends TestCase3 {
 
         @Override
         public boolean getAsBoolean() {
+            System.err.println("CYCLE: " + currentCycle);
             boolean value = currentCycle >= start && currentCycle < end;
             ++currentCycle;
-
-            System.err.println("CYCLE: " + currentCycle);
             System.err.println("VALUE: " + value);
             return value;
         }
@@ -43,27 +42,15 @@ public class RuleEngineTest extends TestCase3 {
 
     private static class PeriodicPredicate implements BooleanSupplier {
         private final int period;
-        private final int start;
-        private final int end;
         private int currentCycle = 0;
 
-        public PeriodicPredicate(int period, int start, int end) {
-            this.period = period;
-            this.start = start;
-            this.end = end;
-        }
-
-        public PeriodicPredicate(int period, int start) {
-            this(period, start, 1);
-        }
-
         public PeriodicPredicate(int period) {
-            this(period, 0);
+            this.period = period;
         }
 
         @Override
         public boolean getAsBoolean() {
-            boolean value = currentCycle % period >= start && currentCycle % period < end;
+            boolean value = currentCycle % period == 0;
             ++currentCycle;
             return value;
         }
@@ -190,7 +177,7 @@ public class RuleEngineTest extends TestCase3 {
 
         cmd = CommandScheduler.getInstance().requiring(fm1);
         assertNotNull(cmd);
-        assertTrue(cmd.getName().endsWith("fm1procfin_p1"));
+        assertTrue(cmd.getName().endsWith("fm1procfin_p0"));
 
         step(); // 1
     }
@@ -336,7 +323,7 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new PeriodicPredicate(4, 1))
+                                Rule.create("fm1_p0", new ScheduledPredicate(1))
                                         .withNewlyTriggeringProcedure(
                                                 () ->
                                                         new FakeProcedure(
@@ -344,7 +331,7 @@ public class RuleEngineTest extends TestCase3 {
                                                                 2,
                                                                 Set.of(fm1, fm2))));
                         addRule(
-                                Rule.create("fm1_p1", new PeriodicPredicate(4, 0))
+                                Rule.create("fm1_p1", new ScheduledPredicate(0))
                                         .withNewlyTriggeringProcedure(
                                                 () ->
                                                         new FakeProcedure(
@@ -378,13 +365,13 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new PeriodicPredicate(4))
+                                Rule.create("fm1_p0", new ScheduledPredicate(0))
                                         .withNewlyTriggeringProcedure(
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p0", 2, Set.of(fm1))));
                         addRule(
-                                Rule.create("fm1_p1", new PeriodicPredicate(4))
+                                Rule.create("fm1_p1", new ScheduledPredicate(0))
                                         .withNewlyTriggeringProcedure(
                                                 () ->
                                                         new FakeProcedure(
@@ -419,13 +406,13 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new PeriodicPredicate(4))
+                                Rule.create("fm1_p0", new ScheduledPredicate(0))
                                         .withNewlyTriggeringProcedure(
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p0", 2, Set.of(fm1))));
                         addRule(
-                                Rule.create("fm1_p1", new PeriodicPredicate(4, 1))
+                                Rule.create("fm1_p1", new ScheduledPredicate(1))
                                         .withNewlyTriggeringProcedure(
                                                 () ->
                                                         new FakeProcedure(
@@ -468,13 +455,13 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new PeriodicPredicate(4, 1))
+                                Rule.create("fm1_p0", new ScheduledPredicate(1))
                                         .withNewlyTriggeringProcedure(
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p0", 2, Set.of(fm1))));
                         addRule(
-                                Rule.create("fm1_p1", new PeriodicPredicate(4))
+                                Rule.create("fm1_p1", new ScheduledPredicate(0))
                                         .withNewlyTriggeringProcedure(
                                                 () ->
                                                         new FakeProcedure(

--- a/src/test/java/com/team766/framework3/RuleEngineTest.java
+++ b/src/test/java/com/team766/framework3/RuleEngineTest.java
@@ -152,7 +152,8 @@ public class RuleEngineTest extends TestCase3 {
 
         step(); // 0
 
-        // next iteration - check that the original procedure is new bumped by the finished procedure for the same rule
+        // next iteration - check that the original procedure is new bumped by the finished
+        // procedure for the same rule
         myRules.run();
 
         cmd = CommandScheduler.getInstance().requiring(fm1);

--- a/vendordeps/PathplannerLib.json
+++ b/vendordeps/PathplannerLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PathplannerLib.json",
     "name": "PathplannerLib",
-    "version": "2024.1.6",
+    "version": "2024.2.8",
     "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
     "frcYear": "2024",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-java",
-            "version": "2024.1.6"
+            "version": "2024.2.8"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-cpp",
-            "version": "2024.1.6",
+            "version": "2024.2.8",
             "libName": "PathplannerLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
## Description

Reset rules when higher priority rules trigger.  Handle the following cases:
- a lower and higher priority rule fire in the same evaluation cycle.  ignore and reset the lower priority rule.
- a higher priority rule fires, and then a lower priority rule is triggered but wants to use mechanisms still in use from the higher priority rule.  ignore and reset the lower priority rule.
- a lower priority rule fires, and then a higher priority rule (using the same mechanism(s)) fires later.  bump and reset the lower priority rule.
- the finished action for a rule bumps the still running newly action for a rule.


## How Has This Been Tested?

Tested via unit tests.

- [x] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
