### PR TITLE
update pathplanner version

### DIFF
--- a/vendordeps/PathplannerLib.json
+++ b/vendordeps/PathplannerLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PathplannerLib.json",
     "name": "PathplannerLib",
-    "version": "2024.1.6",
+    "version": "2024.2.8",
     "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
     "frcYear": "2024",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-java",
-            "version": "2024.1.6"
+            "version": "2024.2.8"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-cpp",
-            "version": "2024.1.6",
+            "version": "2024.2.8",
             "libName": "PathplannerLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
## Description

New builds are failing to find the older pathplanner 1.6 library.  update to the latest pathplanner to get builds working again.

Will require testing on robot to verify that autons work okay with new version.  Sending to allow other builds and development to proceed.

## How Has This Been Tested?

Tree builds again.  Ran unit tests.  Have **not** tested pathfollowing auton on any robots.

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
