### PR TITLE
Rule action persistence policies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,17 @@
   "diffEditor.ignoreTrimWhitespace": false,
   "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml",
   "java.checkstyle.configuration": "${workspaceFolder}/.github/linters/checkstyle.xml",
-  "java.checkstyle.version": "9.3"
+  "java.checkstyle.version": "9.3",
+  "java.completion.favoriteStaticMembers": [
+    "com.team766.framework3.RulePersistence.*",
+    "org.junit.Assert.*",
+    "org.junit.Assume.*",
+    "org.junit.jupiter.api.Assertions.*",
+    "org.junit.jupiter.api.Assumptions.*",
+    "org.junit.jupiter.api.DynamicContainer.*",
+    "org.junit.jupiter.api.DynamicTest.*",
+    "org.mockito.Mockito.*",
+    "org.mockito.ArgumentMatchers.*",
+    "org.mockito.Answers.*"
+  ]
 }

--- a/src/main/java/com/team766/framework3/FunctionalInstantProcedure.java
+++ b/src/main/java/com/team766/framework3/FunctionalInstantProcedure.java
@@ -6,7 +6,12 @@ public final class FunctionalInstantProcedure extends InstantProcedure {
     private final Runnable runnable;
 
     public FunctionalInstantProcedure(Set<Mechanism<?>> reservations, Runnable runnable) {
-        super(runnable.toString(), reservations);
+        this(runnable.toString(), reservations, runnable);
+    }
+
+    public FunctionalInstantProcedure(
+            String name, Set<Mechanism<?>> reservations, Runnable runnable) {
+        super(name, reservations);
         this.runnable = runnable;
     }
 

--- a/src/main/java/com/team766/framework3/FunctionalProcedure.java
+++ b/src/main/java/com/team766/framework3/FunctionalProcedure.java
@@ -7,7 +7,12 @@ public final class FunctionalProcedure extends Procedure {
     private final Consumer<Context> runnable;
 
     public FunctionalProcedure(Set<Mechanism<?>> reservations, Consumer<Context> runnable) {
-        super(runnable.toString(), reservations);
+        this(runnable.toString(), reservations, runnable);
+    }
+
+    public FunctionalProcedure(
+            String name, Set<Mechanism<?>> reservations, Consumer<Context> runnable) {
+        super(name, reservations);
         this.runnable = runnable;
     }
 

--- a/src/main/java/com/team766/framework3/RuleEngine.java
+++ b/src/main/java/com/team766/framework3/RuleEngine.java
@@ -86,7 +86,7 @@ public class RuleEngine implements LoggingBase {
                 rule.evaluate();
 
                 // see if the rule is triggering
-                Rule.TriggerType triggerType = rule.getCurrentTriggerType();
+                final Rule.TriggerType triggerType = rule.getCurrentTriggerType();
                 if (triggerType != Rule.TriggerType.NONE) {
                     log(Severity.INFO, "Rule " + rule.getName() + " triggering: " + triggerType);
 
@@ -148,6 +148,17 @@ public class RuleEngine implements LoggingBase {
                     }
 
                     // we're good to proceed
+
+                    if (triggerType == Rule.TriggerType.FINISHED
+                            && rule.getCancellationOnFinish()
+                                    == Rule.Cancellation.CANCEL_NEWLY_ACTION) {
+                        var newlyCommand =
+                                ruleMap.inverse().get(new RuleAction(rule, Rule.TriggerType.NEWLY));
+                        if (newlyCommand != null) {
+                            newlyCommand.cancel();
+                        }
+                    }
+
                     Procedure procedure = rule.getProcedureToRun();
                     if (procedure == null) {
                         continue;

--- a/src/main/java/com/team766/framework3/RulePersistence.java
+++ b/src/main/java/com/team766/framework3/RulePersistence.java
@@ -1,0 +1,23 @@
+package com.team766.framework3;
+
+/**
+ * Policies for how to handle a Rule's action when the action completes or the Rule stops triggering.
+ */
+public enum RulePersistence {
+    /**
+     * When the action completes, don't do anything. Any Mechanism reservations that the action held
+     * are released. Also, the action may continue running after the Rule stops triggering.
+     */
+    ONCE,
+    /**
+     * When the action completes, don't do anything but retain the Mechanism reservations that the
+     * action held until the Rule stops triggering. If the Rule stops triggering before the action
+     * has completed, then the action will be terminated.
+     */
+    ONCE_AND_HOLD,
+    /**
+     * When the action completes, start executing the action again, until the Rule stops triggering.
+     * The action will be terminated when the Rule stops triggering.
+     */
+    REPEATEDLY,
+}

--- a/src/test/java/com/team766/framework3/RuleEngineTest.java
+++ b/src/test/java/com/team766/framework3/RuleEngineTest.java
@@ -1,6 +1,10 @@
 package com.team766.framework3;
 
+import static com.team766.framework3.RulePersistence.ONCE;
+import static com.team766.framework3.RulePersistence.ONCE_AND_HOLD;
+import static com.team766.framework3.RulePersistence.REPEATEDLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,6 +14,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.Test;
 
@@ -68,12 +73,12 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () -> new FakeProcedure(2, Set.of(fm1))));
+                                        .withOnTriggeringProcedure(
+                                                ONCE, () -> new FakeProcedure(2, Set.of(fm1))));
                         addRule(
                                 Rule.create("fm1_p1", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () -> new FakeProcedure(2, Set.of(fm1))));
+                                        .withOnTriggeringProcedure(
+                                                ONCE, () -> new FakeProcedure(2, Set.of(fm1))));
                     }
                 };
 
@@ -97,12 +102,12 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () -> new FakeProcedure(2, Set.of(fm1))));
+                                        .withOnTriggeringProcedure(
+                                                ONCE, () -> new FakeProcedure(2, Set.of(fm1))));
                         addRule(
                                 Rule.create("fm2", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () -> new FakeProcedure(2, Set.of(fm2))));
+                                        .withOnTriggeringProcedure(
+                                                ONCE, () -> new FakeProcedure(2, Set.of(fm2))));
                     }
                 };
 
@@ -147,7 +152,8 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p0", 1, Set.of(fm1)))
@@ -189,7 +195,8 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1proc_p0",
@@ -197,7 +204,8 @@ public class RuleEngineTest extends TestCase3 {
                                                                 Set.of(fm1, fm2))));
                         addRule(
                                 Rule.create("fm1_p1", new PeriodicPredicate(2))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1proc_p1",
@@ -206,7 +214,8 @@ public class RuleEngineTest extends TestCase3 {
 
                         addRule(
                                 Rule.create("fm3_p2", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm3proc_p2", 0, Set.of(fm3))));
@@ -251,7 +260,8 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1proc_p0",
@@ -259,7 +269,8 @@ public class RuleEngineTest extends TestCase3 {
                                                                 Set.of(fm1, fm2))));
                         addRule(
                                 Rule.create("fm1_p1", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1proc_p1",
@@ -268,7 +279,8 @@ public class RuleEngineTest extends TestCase3 {
 
                         addRule(
                                 Rule.create("fm1_p2", new ScheduledPredicate(3))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1proc_p2",
@@ -322,7 +334,8 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1_p0", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1proc_p0",
@@ -330,7 +343,8 @@ public class RuleEngineTest extends TestCase3 {
                                                                 Set.of(fm1, fm2))));
                         addRule(
                                 Rule.create("fm1_p1", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1proc_p1",
@@ -364,13 +378,15 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p0", 2, Set.of(fm1))));
                         addRule(
                                 Rule.create("fm1_p1", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p1", 1, Set.of(fm1)))
@@ -405,13 +421,15 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p0", 2, Set.of(fm1))));
                         addRule(
                                 Rule.create("fm1_p1", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p1", 1, Set.of(fm1)))
@@ -454,13 +472,15 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1_p0", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p0", 2, Set.of(fm1))));
                         addRule(
                                 Rule.create("fm1_p1", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p1", 2, Set.of(fm1)))
@@ -495,7 +515,8 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1_p0", new ScheduledPredicate(0, 4))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p0", 0, Set.of(fm1)))
@@ -505,7 +526,8 @@ public class RuleEngineTest extends TestCase3 {
                                                                 "fm1procfin_p0", 0, Set.of(fm1))));
                         addRule(
                                 Rule.create("fm1_p1", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p1", 0, Set.of(fm1)))
@@ -564,7 +586,8 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1_p0", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p0", 0, Set.of(fm1)))
@@ -574,7 +597,8 @@ public class RuleEngineTest extends TestCase3 {
                                                                 "fm1procfin_p0", 0, Set.of(fm1))));
                         addRule(
                                 Rule.create("fm1_p1", new ScheduledPredicate(0, 4))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p1", 1, Set.of(fm1)))
@@ -634,7 +658,8 @@ public class RuleEngineTest extends TestCase3 {
                     {
                         addRule(
                                 Rule.create("fm1_p0", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p0", 0, Set.of(fm1)))
@@ -644,7 +669,8 @@ public class RuleEngineTest extends TestCase3 {
                                                                 "fm1procfin_p0", 0, Set.of(fm1))));
                         addRule(
                                 Rule.create("fm1_p1", new ScheduledPredicate(0, 3))
-                                        .withNewlyTriggeringProcedure(
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
                                                 () ->
                                                         new FakeProcedure(
                                                                 "fm1procnew_p1", 1, Set.of(fm1)))
@@ -686,5 +712,213 @@ public class RuleEngineTest extends TestCase3 {
         assertNull(cmd);
 
         step(); // 3
+    }
+
+    /** Test ONCE RulePersistence policy */
+    @Test
+    public void testOncePersistence() {
+        AtomicReference<FakeProcedure> predicateEndsFirstProc = new AtomicReference<>();
+        AtomicReference<FakeProcedure> actionEndsFirstProc = new AtomicReference<>();
+        RuleEngine myRules =
+                new RuleEngine() {
+                    {
+                        addRule(
+                                Rule.create("predicate_ends_first", new ScheduledPredicate(0, 1))
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
+                                                () -> {
+                                                    var proc =
+                                                            new FakeProcedure(
+                                                                    "predicate_ends_first_proc",
+                                                                    10,
+                                                                    Set.of(fm1));
+                                                    predicateEndsFirstProc.set(proc);
+                                                    return proc;
+                                                }));
+                        addRule(
+                                Rule.create("action_ends_first", new ScheduledPredicate(0, 10))
+                                        .withOnTriggeringProcedure(
+                                                ONCE,
+                                                () -> {
+                                                    var proc =
+                                                            new FakeProcedure(
+                                                                    "action_ends_first_proc",
+                                                                    1,
+                                                                    Set.of(fm2));
+                                                    actionEndsFirstProc.set(proc);
+                                                    return proc;
+                                                }));
+                    }
+                };
+
+        myRules.run();
+
+        // check that both action Procedures are scheduled
+        Command cmd1 = CommandScheduler.getInstance().requiring(fm1);
+        assertNotNull(cmd1);
+        assertTrue(cmd1.getName().endsWith("predicate_ends_first_proc"));
+        Command cmd2 = CommandScheduler.getInstance().requiring(fm2);
+        assertNotNull(cmd2);
+        assertTrue(cmd2.getName().endsWith("action_ends_first_proc"));
+
+        step();
+        myRules.run();
+        step();
+        myRules.run();
+
+        // ONCE actions should be allowed to run after the rule has stopped triggering.
+        assertEquals(2, predicateEndsFirstProc.get().age());
+        assertFalse(predicateEndsFirstProc.get().isEnded());
+        cmd1 = CommandScheduler.getInstance().requiring(fm1);
+        assertNotNull(cmd1);
+        assertTrue(cmd1.getName().endsWith("predicate_ends_first_proc"));
+
+        // If a ONCE action completes, it should end and mechanism reservations released.
+        assertTrue(actionEndsFirstProc.get().isEnded());
+        cmd2 = CommandScheduler.getInstance().requiring(fm2);
+        assertNull(cmd2);
+    }
+
+    /** Test ONCE_AND_HOLD RulePersistence policy */
+    @Test
+    public void testOnceAndHoldPersistence() {
+        AtomicReference<FakeProcedure> predicateEndsFirstProc = new AtomicReference<>();
+        AtomicReference<FakeProcedure> actionEndsFirstProc = new AtomicReference<>();
+        RuleEngine myRules =
+                new RuleEngine() {
+                    {
+                        addRule(
+                                Rule.create("predicate_ends_first", new ScheduledPredicate(0, 1))
+                                        .withOnTriggeringProcedure(
+                                                ONCE_AND_HOLD,
+                                                () -> {
+                                                    var proc =
+                                                            new FakeProcedure(
+                                                                    "predicate_ends_first_proc",
+                                                                    10,
+                                                                    Set.of(fm1));
+                                                    predicateEndsFirstProc.set(proc);
+                                                    return proc;
+                                                }));
+                        addRule(
+                                Rule.create("action_ends_first", new ScheduledPredicate(0, 10))
+                                        .withOnTriggeringProcedure(
+                                                ONCE_AND_HOLD,
+                                                () -> {
+                                                    var proc =
+                                                            new FakeProcedure(
+                                                                    "action_ends_first_proc",
+                                                                    1,
+                                                                    Set.of(fm2));
+                                                    actionEndsFirstProc.set(proc);
+                                                    return proc;
+                                                }));
+                    }
+                };
+
+        myRules.run();
+
+        // check that both action Procedures are scheduled
+        Command cmd1 = CommandScheduler.getInstance().requiring(fm1);
+        assertNotNull(cmd1);
+        assertTrue(cmd1.getName().endsWith("predicate_ends_first_proc"));
+        Command cmd2 = CommandScheduler.getInstance().requiring(fm2);
+        assertNotNull(cmd2);
+        assertTrue(cmd2.getName().endsWith("action_ends_first_proc"));
+
+        step();
+        myRules.run();
+        step();
+        myRules.run();
+
+        // ONCE_AND_HOLD actions should be cancelled after the rule has stopped triggering.
+        assertTrue(predicateEndsFirstProc.get().isEnded());
+        cmd1 = CommandScheduler.getInstance().requiring(fm1);
+        assertNull(cmd1);
+
+        // If a ONCE_AND_HOLD action completes, it should end but mechanism reservations are
+        // retained.
+        assertTrue(actionEndsFirstProc.get().isEnded());
+        cmd2 = CommandScheduler.getInstance().requiring(fm2);
+        assertNotNull(cmd2);
+        assertTrue(cmd2.getName().endsWith("action_ends_first_proc"));
+    }
+
+    /** Test REPEATEDLY RulePersistence policy */
+    @Test
+    public void testRepeatedlyPersistence() {
+        AtomicReference<FakeProcedure> predicateEndsFirstProc = new AtomicReference<>();
+        AtomicReference<FakeProcedure> actionEndsFirstProc = new AtomicReference<>();
+        RuleEngine myRules =
+                new RuleEngine() {
+                    {
+                        addRule(
+                                Rule.create("predicate_ends_first", new ScheduledPredicate(0, 1))
+                                        .withOnTriggeringProcedure(
+                                                REPEATEDLY,
+                                                () -> {
+                                                    var proc =
+                                                            new FakeProcedure(
+                                                                    "predicate_ends_first_proc",
+                                                                    10,
+                                                                    Set.of(fm1));
+                                                    predicateEndsFirstProc.set(proc);
+                                                    return proc;
+                                                }));
+                        addRule(
+                                Rule.create("action_ends_first", new ScheduledPredicate(0, 10))
+                                        .withOnTriggeringProcedure(
+                                                REPEATEDLY,
+                                                () -> {
+                                                    var proc =
+                                                            new FakeProcedure(
+                                                                    "action_ends_first_proc",
+                                                                    1,
+                                                                    Set.of(fm2));
+                                                    actionEndsFirstProc.set(proc);
+                                                    return proc;
+                                                }));
+                    }
+                };
+
+        myRules.run();
+
+        // check that both action Procedures are scheduled
+        Command cmd1 = CommandScheduler.getInstance().requiring(fm1);
+        assertNotNull(cmd1);
+        assertTrue(cmd1.getName().endsWith("predicate_ends_first_proc"));
+        Command cmd2 = CommandScheduler.getInstance().requiring(fm2);
+        assertNotNull(cmd2);
+        assertTrue(cmd2.getName().endsWith("action_ends_first_proc"));
+
+        step();
+        myRules.run();
+        step();
+        myRules.run();
+        step();
+
+        // REPEATEDLY actions should be cancelled after the rule has stopped triggering.
+        assertTrue(predicateEndsFirstProc.get().isEnded());
+        cmd1 = CommandScheduler.getInstance().requiring(fm1);
+        assertNull(cmd1);
+
+        // If a REPEATEDLY action completes, another instance should be started.
+        assertFalse(actionEndsFirstProc.get().isEnded());
+        cmd2 = CommandScheduler.getInstance().requiring(fm2);
+        assertNotNull(cmd2);
+        assertTrue(cmd2.getName().endsWith("action_ends_first_proc"));
+
+        final FakeProcedure previousActionInstance = actionEndsFirstProc.get();
+
+        myRules.run();
+        step();
+        myRules.run();
+        step();
+
+        assertTrue(previousActionInstance.isEnded());
+        assertFalse(actionEndsFirstProc.get().isEnded());
+        cmd2 = CommandScheduler.getInstance().requiring(fm2);
+        assertNotNull(cmd2);
+        assertTrue(cmd2.getName().endsWith("action_ends_first_proc"));
     }
 }

--- a/src/test/java/com/team766/framework3/RuleTest.java
+++ b/src/test/java/com/team766/framework3/RuleTest.java
@@ -1,9 +1,13 @@
 package com.team766.framework3;
 
+import static com.team766.framework3.RulePersistence.ONCE;
+import static com.team766.framework3.RulePersistence.ONCE_AND_HOLD;
+import static com.team766.framework3.RulePersistence.REPEATEDLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.team766.framework3.Rule.Cancellation;
 import com.team766.framework3.Rule.TriggerType;
 import java.util.Collections;
 import java.util.Set;
@@ -43,7 +47,7 @@ public class RuleTest {
     public void testCreate() {
         Rule alwaysTrue =
                 Rule.create("always true", () -> true)
-                        .withNewlyTriggeringProcedure(() -> Procedure.NO_OP)
+                        .withOnTriggeringProcedure(ONCE, () -> Procedure.NO_OP)
                         .build();
         assertNotNull(alwaysTrue);
         assertEquals("always true", alwaysTrue.getName());
@@ -54,7 +58,7 @@ public class RuleTest {
         // start with simple test of a NONE->NEWLY->CONTINUING->CONTINUING sequence
         Rule alwaysTrue =
                 Rule.create("always true", () -> true)
-                        .withNewlyTriggeringProcedure(() -> Procedure.NO_OP)
+                        .withOnTriggeringProcedure(ONCE, () -> Procedure.NO_OP)
                         .build();
         assertEquals(Rule.TriggerType.NONE, alwaysTrue.getCurrentTriggerType());
         alwaysTrue.evaluate();
@@ -67,7 +71,7 @@ public class RuleTest {
         // test a full cycle: NONE->NEWLY->CONTINUING->FINISHED->NONE->NEWLY->...
         Rule duckDuckGooseGoose =
                 Rule.create("duck duck goose goose", new DuckDuckGooseGoosePredicate())
-                        .withNewlyTriggeringProcedure(() -> Procedure.NO_OP)
+                        .withOnTriggeringProcedure(ONCE, () -> Procedure.NO_OP)
                         .build();
         assertEquals(Rule.TriggerType.NONE, duckDuckGooseGoose.getCurrentTriggerType());
         duckDuckGooseGoose.evaluate();
@@ -83,6 +87,29 @@ public class RuleTest {
     }
 
     @Test
+    public void testGetCancellation() {
+        Rule ruleWithOnce =
+                Rule.create("always true", new DuckDuckGooseGoosePredicate())
+                        .withOnTriggeringProcedure(ONCE, () -> Procedure.NO_OP)
+                        .build();
+        assertEquals(Cancellation.DO_NOT_CANCEL, ruleWithOnce.getCancellationOnFinish());
+
+        Rule ruleWithOnceAndHold =
+                Rule.create("always true", new DuckDuckGooseGoosePredicate())
+                        .withOnTriggeringProcedure(ONCE_AND_HOLD, () -> Procedure.NO_OP)
+                        .build();
+        assertEquals(
+                Cancellation.CANCEL_NEWLY_ACTION, ruleWithOnceAndHold.getCancellationOnFinish());
+
+        Rule ruleWithRepeatedly =
+                Rule.create("always true", new DuckDuckGooseGoosePredicate())
+                        .withOnTriggeringProcedure(REPEATEDLY, () -> Procedure.NO_OP)
+                        .build();
+        assertEquals(
+                Cancellation.CANCEL_NEWLY_ACTION, ruleWithRepeatedly.getCancellationOnFinish());
+    }
+
+    @Test
     public void testGetMechanismsToReserve() {
         final Set<Mechanism<?>> newlyMechanisms =
                 Set.of(new FakeMechanism1(), new FakeMechanism2());
@@ -90,7 +117,7 @@ public class RuleTest {
 
         Rule duckDuckGooseGoose =
                 Rule.create("duck duck goose goose", new DuckDuckGooseGoosePredicate())
-                        .withNewlyTriggeringProcedure(newlyMechanisms, () -> {})
+                        .withOnTriggeringProcedure(ONCE, newlyMechanisms, () -> {})
                         .withFinishedTriggeringProcedure(finishedMechanisms, () -> {})
                         .build();
 
@@ -122,7 +149,7 @@ public class RuleTest {
     public void testGetProcedureToRun() {
         Rule duckDuckGooseGoose =
                 Rule.create("duck duck goose goose", new DuckDuckGooseGoosePredicate())
-                        .withNewlyTriggeringProcedure(() -> new TrivialProcedure("newly"))
+                        .withOnTriggeringProcedure(ONCE, () -> new TrivialProcedure("newly"))
                         .withFinishedTriggeringProcedure(() -> new TrivialProcedure("finished"))
                         .build();
 


### PR DESCRIPTION
## Description

Allow the user to specify how the RuleEngine should handle a Rule's action when the action completes or the Rule stops triggering.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Be detailed so that your code reviewer can understand exactly how much and what kinds of testing were done, and which might still be worthwhile to do.

- [X] Unit tests: Units tests for new functionality are included in this PR
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
