### PR TITLE
Simplify RuleEngine API

### DIFF
--- a/src/main/java/com/team766/framework3/Rule.java
+++ b/src/main/java/com/team766/framework3/Rule.java
@@ -57,6 +57,7 @@ public class Rule {
             Maps.newEnumMap(TriggerType.class);
 
     private TriggerType currentTriggerType = TriggerType.NONE;
+    private boolean sealed = false;
 
     /* package */ Rule(
             String name, BooleanSupplier predicate, Supplier<Procedure> newlyTriggeringProcedure) {
@@ -79,6 +80,11 @@ public class Rule {
 
     /** Specify a creator for the Procedure that should be run when this rule was triggering before and is no longer triggering. */
     public Rule withFinishedTriggeringProcedure(Supplier<Procedure> action) {
+        if (sealed) {
+            throw new IllegalStateException(
+                    "Cannot modify rules once they've been evaluated in the RuleEngine");
+        }
+
         triggerProcedures.put(TriggerType.FINISHED, action);
         triggerReservations.put(TriggerType.FINISHED, getReservationsForProcedure(action));
         return this;
@@ -105,6 +111,10 @@ public class Rule {
 
     /* package */ TriggerType getCurrentTriggerType() {
         return currentTriggerType;
+    }
+
+    /* package */ void seal() {
+        sealed = true;
     }
 
     /* package */ void reset() {

--- a/src/main/java/com/team766/framework3/RuleEngine.java
+++ b/src/main/java/com/team766/framework3/RuleEngine.java
@@ -14,6 +14,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 /**
  * {@link RuleEngine}s manage and process a set of {@link Rule}s.  Subclasses should add rules via
@@ -41,11 +43,18 @@ public class RuleEngine implements LoggingBase {
         return Category.RULES;
     }
 
-    protected void addRule(Rule.Builder builder) {
-        Rule rule = builder.build();
+    protected Rule addRule(String name, BooleanSupplier condition, Supplier<Procedure> action) {
+        Rule rule = new Rule(name, condition, action);
         rules.add(rule);
         int priority = rulePriorities.size();
         rulePriorities.put(rule, priority);
+        return rule;
+    }
+
+    protected Rule addRule(
+            String name, BooleanSupplier condition, Mechanism<?> mechanism, Runnable action) {
+        return addRule(
+                name, condition, () -> new FunctionalInstantProcedure(Set.of(mechanism), action));
     }
 
     @VisibleForTesting

--- a/src/test/java/com/team766/framework3/RuleEngineTest.java
+++ b/src/test/java/com/team766/framework3/RuleEngineTest.java
@@ -3,12 +3,12 @@ package com.team766.framework3;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.team766.TestCase3;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.Test;
@@ -59,6 +59,34 @@ public class RuleEngineTest extends TestCase3 {
     private final FakeMechanism3 fm3 = new FakeMechanism3();
 
     @Test
+    public void testSeal() {
+        // test that we can modify rules before we call run
+        RuleEngine rulesOne =
+                new RuleEngine() {
+                    {
+                        addRule("rule1_1", () -> true, () -> Procedure.NO_OP)
+                                .withFinishedTriggeringProcedure(() -> Procedure.NO_OP);
+                    }
+                };
+        rulesOne.run();
+
+        // test that
+        RuleEngine rulesTwo =
+                new RuleEngine() {
+                    {
+                        addRule("rule2_1", () -> true, () -> Procedure.NO_OP);
+                    }
+                };
+        rulesTwo.run();
+
+        assertThrows(
+                IllegalStateException.class,
+                () ->
+                        rulesTwo.getRuleByName("rule2_1")
+                                .withFinishedTriggeringProcedure(() -> Procedure.NO_OP));
+    }
+
+    @Test
     public void testAddRuleAndGetPriority() {
         // simply test that rules we add are added - and at the expected priority
 
@@ -77,12 +105,11 @@ public class RuleEngineTest extends TestCase3 {
                     }
                 };
 
-        Map<String, Rule> namedRules = myRules.getRuleNameMap();
         // make sure we have 2 rules
-        assertEquals(2, namedRules.size());
+        assertEquals(2, myRules.size());
         // with priorities based on insertion order, starting at 0
-        assertEquals(0, myRules.getPriorityForRule(namedRules.get("fm1_p0")));
-        assertEquals(1, myRules.getPriorityForRule(namedRules.get("fm1_p1")));
+        assertEquals(0, myRules.getPriorityForRule(myRules.getRuleByName("fm1_p0")));
+        assertEquals(1, myRules.getPriorityForRule(myRules.getRuleByName("fm1_p1")));
     }
 
     @Test

--- a/src/test/java/com/team766/framework3/RuleEngineTest.java
+++ b/src/test/java/com/team766/framework3/RuleEngineTest.java
@@ -67,13 +67,13 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () -> new FakeProcedure(2, Set.of(fm1))));
+                                "fm1_p0",
+                                new ScheduledPredicate(0),
+                                () -> new FakeProcedure(2, Set.of(fm1)));
                         addRule(
-                                Rule.create("fm1_p1", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () -> new FakeProcedure(2, Set.of(fm1))));
+                                "fm1_p1",
+                                new ScheduledPredicate(0),
+                                () -> new FakeProcedure(2, Set.of(fm1)));
                     }
                 };
 
@@ -96,13 +96,13 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () -> new FakeProcedure(2, Set.of(fm1))));
+                                "fm1",
+                                new ScheduledPredicate(0),
+                                () -> new FakeProcedure(2, Set.of(fm1)));
                         addRule(
-                                Rule.create("fm2", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () -> new FakeProcedure(2, Set.of(fm2))));
+                                "fm2",
+                                new ScheduledPredicate(0),
+                                () -> new FakeProcedure(2, Set.of(fm2)));
                     }
                 };
 
@@ -146,17 +146,13 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p0", 1, Set.of(fm1)))
-                                        .withFinishedTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procfin_p0",
-                                                                1,
-                                                                Set.of(fm1, fm2))));
+                                        "fm1_p0",
+                                        new ScheduledPredicate(0),
+                                        () -> new FakeProcedure("fm1procnew_p0", 1, Set.of(fm1)))
+                                .withFinishedTriggeringProcedure(
+                                        () ->
+                                                new FakeProcedure(
+                                                        "fm1procfin_p0", 1, Set.of(fm1, fm2)));
                     }
                 };
 
@@ -188,28 +184,18 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1proc_p0",
-                                                                0,
-                                                                Set.of(fm1, fm2))));
+                                "fm1_p0",
+                                new ScheduledPredicate(0),
+                                () -> new FakeProcedure("fm1proc_p0", 0, Set.of(fm1, fm2)));
                         addRule(
-                                Rule.create("fm1_p1", new PeriodicPredicate(2))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1proc_p1",
-                                                                0,
-                                                                Set.of(fm1, fm3))));
+                                "fm1_p1",
+                                new PeriodicPredicate(2),
+                                () -> new FakeProcedure("fm1proc_p1", 0, Set.of(fm1, fm3)));
 
                         addRule(
-                                Rule.create("fm3_p2", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm3proc_p2", 0, Set.of(fm3))));
+                                "fm3_p2",
+                                new ScheduledPredicate(0),
+                                () -> new FakeProcedure("fm3proc_p2", 0, Set.of(fm3)));
                     }
                 };
 
@@ -250,30 +236,18 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1proc_p0",
-                                                                2,
-                                                                Set.of(fm1, fm2))));
+                                "fm1_p0",
+                                new ScheduledPredicate(0),
+                                () -> new FakeProcedure("fm1proc_p0", 2, Set.of(fm1, fm2)));
                         addRule(
-                                Rule.create("fm1_p1", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1proc_p1",
-                                                                2,
-                                                                Set.of(fm1, fm2))));
+                                "fm1_p1",
+                                new ScheduledPredicate(1),
+                                () -> new FakeProcedure("fm1proc_p1", 2, Set.of(fm1, fm2)));
 
                         addRule(
-                                Rule.create("fm1_p2", new ScheduledPredicate(3))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1proc_p2",
-                                                                2,
-                                                                Set.of(fm1, fm2))));
+                                "fm1_p2",
+                                new ScheduledPredicate(3),
+                                () -> new FakeProcedure("fm1proc_p2", 2, Set.of(fm1, fm2)));
                     }
                 };
 
@@ -321,21 +295,13 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1proc_p0",
-                                                                2,
-                                                                Set.of(fm1, fm2))));
+                                "fm1_p0",
+                                new ScheduledPredicate(1),
+                                () -> new FakeProcedure("fm1proc_p0", 2, Set.of(fm1, fm2)));
                         addRule(
-                                Rule.create("fm1_p1", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1proc_p1",
-                                                                4,
-                                                                Set.of(fm1, fm2))));
+                                "fm1_p1",
+                                new ScheduledPredicate(0),
+                                () -> new FakeProcedure("fm1proc_p1", 4, Set.of(fm1, fm2)));
                     }
                 };
 
@@ -363,21 +329,15 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p0", 2, Set.of(fm1))));
+                                "fm1_p0",
+                                new ScheduledPredicate(0),
+                                () -> new FakeProcedure("fm1procnew_p0", 2, Set.of(fm1)));
                         addRule(
-                                Rule.create("fm1_p1", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p1", 1, Set.of(fm1)))
-                                        .withFinishedTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procfin_p1", 1, Set.of(fm2))));
+                                        "fm1_p1",
+                                        new ScheduledPredicate(0),
+                                        () -> new FakeProcedure("fm1procnew_p1", 1, Set.of(fm1)))
+                                .withFinishedTriggeringProcedure(
+                                        () -> new FakeProcedure("fm1procfin_p1", 1, Set.of(fm2)));
                     }
                 };
 
@@ -404,21 +364,15 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p0", 2, Set.of(fm1))));
+                                "fm1_p0",
+                                new ScheduledPredicate(0),
+                                () -> new FakeProcedure("fm1procnew_p0", 2, Set.of(fm1)));
                         addRule(
-                                Rule.create("fm1_p1", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p1", 1, Set.of(fm1)))
-                                        .withFinishedTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procfin_p1", 1, Set.of(fm2))));
+                                        "fm1_p1",
+                                        new ScheduledPredicate(1),
+                                        () -> new FakeProcedure("fm1procnew_p1", 1, Set.of(fm1)))
+                                .withFinishedTriggeringProcedure(
+                                        () -> new FakeProcedure("fm1procfin_p1", 1, Set.of(fm2)));
                     }
                 };
 
@@ -453,21 +407,15 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p0", 2, Set.of(fm1))));
+                                "fm1_p0",
+                                new ScheduledPredicate(1),
+                                () -> new FakeProcedure("fm1procnew_p0", 2, Set.of(fm1)));
                         addRule(
-                                Rule.create("fm1_p1", new ScheduledPredicate(0))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p1", 2, Set.of(fm1)))
-                                        .withFinishedTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procfin_p1", 2, Set.of(fm2))));
+                                        "fm1_p1",
+                                        new ScheduledPredicate(0),
+                                        () -> new FakeProcedure("fm1procnew_p1", 2, Set.of(fm1)))
+                                .withFinishedTriggeringProcedure(
+                                        () -> new FakeProcedure("fm1procfin_p1", 2, Set.of(fm2)));
                     }
                 };
 
@@ -494,25 +442,17 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new ScheduledPredicate(0, 4))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p0", 0, Set.of(fm1)))
-                                        .withFinishedTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procfin_p0", 0, Set.of(fm1))));
+                                        "fm1_p0",
+                                        new ScheduledPredicate(0, 4),
+                                        () -> new FakeProcedure("fm1procnew_p0", 0, Set.of(fm1)))
+                                .withFinishedTriggeringProcedure(
+                                        () -> new FakeProcedure("fm1procfin_p0", 0, Set.of(fm1)));
                         addRule(
-                                Rule.create("fm1_p1", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p1", 0, Set.of(fm1)))
-                                        .withFinishedTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procfin_p1", 0, Set.of(fm1))));
+                                        "fm1_p1",
+                                        new ScheduledPredicate(1),
+                                        () -> new FakeProcedure("fm1procnew_p1", 0, Set.of(fm1)))
+                                .withFinishedTriggeringProcedure(
+                                        () -> new FakeProcedure("fm1procfin_p1", 0, Set.of(fm1)));
                     }
                 };
 
@@ -563,25 +503,17 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p0", 0, Set.of(fm1)))
-                                        .withFinishedTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procfin_p0", 0, Set.of(fm1))));
+                                        "fm1_p0",
+                                        new ScheduledPredicate(1),
+                                        () -> new FakeProcedure("fm1procnew_p0", 0, Set.of(fm1)))
+                                .withFinishedTriggeringProcedure(
+                                        () -> new FakeProcedure("fm1procfin_p0", 0, Set.of(fm1)));
                         addRule(
-                                Rule.create("fm1_p1", new ScheduledPredicate(0, 4))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p1", 1, Set.of(fm1)))
-                                        .withFinishedTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procfin_p1", 1, Set.of(fm1))));
+                                        "fm1_p1",
+                                        new ScheduledPredicate(0, 4),
+                                        () -> new FakeProcedure("fm1procnew_p1", 1, Set.of(fm1)))
+                                .withFinishedTriggeringProcedure(
+                                        () -> new FakeProcedure("fm1procfin_p1", 1, Set.of(fm1)));
                     }
                 };
 
@@ -633,25 +565,17 @@ public class RuleEngineTest extends TestCase3 {
                 new RuleEngine() {
                     {
                         addRule(
-                                Rule.create("fm1_p0", new ScheduledPredicate(1))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p0", 0, Set.of(fm1)))
-                                        .withFinishedTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procfin_p0", 0, Set.of(fm1))));
+                                        "fm1_p0",
+                                        new ScheduledPredicate(1),
+                                        () -> new FakeProcedure("fm1procnew_p0", 0, Set.of(fm1)))
+                                .withFinishedTriggeringProcedure(
+                                        () -> new FakeProcedure("fm1procfin_p0", 0, Set.of(fm1)));
                         addRule(
-                                Rule.create("fm1_p1", new ScheduledPredicate(0, 3))
-                                        .withNewlyTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procnew_p1", 1, Set.of(fm1)))
-                                        .withFinishedTriggeringProcedure(
-                                                () ->
-                                                        new FakeProcedure(
-                                                                "fm1procfin_p1", 1, Set.of(fm1))));
+                                        "fm1_p1",
+                                        new ScheduledPredicate(0, 3),
+                                        () -> new FakeProcedure("fm1procnew_p1", 1, Set.of(fm1)))
+                                .withFinishedTriggeringProcedure(
+                                        () -> new FakeProcedure("fm1procfin_p1", 1, Set.of(fm1)));
                     }
                 };
 

--- a/src/test/java/com/team766/framework3/RuleTest.java
+++ b/src/test/java/com/team766/framework3/RuleTest.java
@@ -41,10 +41,7 @@ public class RuleTest {
 
     @Test
     public void testCreate() {
-        Rule alwaysTrue =
-                Rule.create("always true", () -> true)
-                        .withNewlyTriggeringProcedure(() -> Procedure.NO_OP)
-                        .build();
+        Rule alwaysTrue = new Rule("always true", () -> true, () -> Procedure.NO_OP);
         assertNotNull(alwaysTrue);
         assertEquals("always true", alwaysTrue.getName());
     }
@@ -52,10 +49,7 @@ public class RuleTest {
     @Test
     public void testEvaluate() {
         // start with simple test of a NONE->NEWLY->CONTINUING->CONTINUING sequence
-        Rule alwaysTrue =
-                Rule.create("always true", () -> true)
-                        .withNewlyTriggeringProcedure(() -> Procedure.NO_OP)
-                        .build();
+        Rule alwaysTrue = new Rule("always true", () -> true, () -> Procedure.NO_OP);
         assertEquals(Rule.TriggerType.NONE, alwaysTrue.getCurrentTriggerType());
         alwaysTrue.evaluate();
         assertEquals(TriggerType.NEWLY, alwaysTrue.getCurrentTriggerType());
@@ -66,9 +60,10 @@ public class RuleTest {
 
         // test a full cycle: NONE->NEWLY->CONTINUING->FINISHED->NONE->NEWLY->...
         Rule duckDuckGooseGoose =
-                Rule.create("duck duck goose goose", new DuckDuckGooseGoosePredicate())
-                        .withNewlyTriggeringProcedure(() -> Procedure.NO_OP)
-                        .build();
+                new Rule(
+                        "duck duck goose goose",
+                        new DuckDuckGooseGoosePredicate(),
+                        () -> Procedure.NO_OP);
         assertEquals(Rule.TriggerType.NONE, duckDuckGooseGoose.getCurrentTriggerType());
         duckDuckGooseGoose.evaluate();
         assertEquals(TriggerType.NEWLY, duckDuckGooseGoose.getCurrentTriggerType());
@@ -89,10 +84,11 @@ public class RuleTest {
         final Set<Mechanism<?>> finishedMechanisms = Set.of(new FakeMechanism());
 
         Rule duckDuckGooseGoose =
-                Rule.create("duck duck goose goose", new DuckDuckGooseGoosePredicate())
-                        .withNewlyTriggeringProcedure(newlyMechanisms, () -> {})
-                        .withFinishedTriggeringProcedure(finishedMechanisms, () -> {})
-                        .build();
+                new Rule(
+                                "duck duck goose goose",
+                                new DuckDuckGooseGoosePredicate(),
+                                () -> new FunctionalInstantProcedure(newlyMechanisms, () -> {}))
+                        .withFinishedTriggeringProcedure(finishedMechanisms, () -> {});
 
         // NONE
         assertEquals(Collections.emptySet(), duckDuckGooseGoose.getMechanismsToReserve());
@@ -101,12 +97,13 @@ public class RuleTest {
         duckDuckGooseGoose.evaluate();
         assertEquals(newlyMechanisms, duckDuckGooseGoose.getMechanismsToReserve());
 
-        // nothing between NEWLLY and FINISHED
+        // nothing between NEWLY and FINISHED
         duckDuckGooseGoose.evaluate();
         assertEquals(Collections.emptySet(), duckDuckGooseGoose.getMechanismsToReserve());
 
         // FINISHED
         duckDuckGooseGoose.evaluate();
+        System.out.println("X: " + duckDuckGooseGoose.toString());
         assertEquals(finishedMechanisms, duckDuckGooseGoose.getMechanismsToReserve());
 
         // check NONE again
@@ -121,10 +118,11 @@ public class RuleTest {
     @Test
     public void testGetProcedureToRun() {
         Rule duckDuckGooseGoose =
-                Rule.create("duck duck goose goose", new DuckDuckGooseGoosePredicate())
-                        .withNewlyTriggeringProcedure(() -> new TrivialProcedure("newly"))
-                        .withFinishedTriggeringProcedure(() -> new TrivialProcedure("finished"))
-                        .build();
+                new Rule(
+                                "duck duck goose goose",
+                                new DuckDuckGooseGoosePredicate(),
+                                () -> new TrivialProcedure("newly"))
+                        .withFinishedTriggeringProcedure(() -> new TrivialProcedure("finished"));
 
         // NONE
         assertNull(duckDuckGooseGoose.getProcedureToRun());


### PR DESCRIPTION
## Description

Remove `Rule.Builder`.  Callers still call `RuleEngine.addRule()`, with simplified syntax.  Allow `Rule`s to be modified, eg to specify a finishedTriggering action - but once `RuleEngine.run()` is called, "seal" the `RuleEngine`'s `Rule`s so they cannot be modified further.


## How Has This Been Tested?

- [x] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [ ] On-robot bench testing: [Add your description here]
- [ ] On-robot field testing: [Add your description here]
